### PR TITLE
Two small fixes in generative processes:

### DIFF
--- a/simplexity/generative_processes/builder.py
+++ b/simplexity/generative_processes/builder.py
@@ -42,8 +42,11 @@ def add_begin_of_sequence_token(transition_matrix: jax.Array, initial_state: jax
     return augmented_matrix.at[vocab_size, num_states, :num_states].set(initial_state)
 
 
-def build_hidden_markov_model(process_name: str, initial_state: jax.Array | None = None, **kwargs) -> HiddenMarkovModel:
+def build_hidden_markov_model(
+    process_name: str, initial_state: jax.Array | Sequence[float] | None = None, **kwargs
+) -> HiddenMarkovModel:
     """Build a hidden Markov model."""
+    initial_state = jnp.array(initial_state) if initial_state is not None else None
     transition_matrices = build_transition_matrices(HMM_MATRIX_FUNCTIONS, process_name, **kwargs)
     return HiddenMarkovModel(transition_matrices, initial_state)
 

--- a/simplexity/generative_processes/transition_matrices.py
+++ b/simplexity/generative_processes/transition_matrices.py
@@ -360,6 +360,7 @@ HMM_MATRIX_FUNCTIONS = {
     "coin": coin,
     "days_of_week": days_of_week,
     "even_ones": even_ones,
+    "matching_parens": matching_parens,
     "mess3": mess3,
     "mr_name": mr_name,
     "no_consecutive_ones": no_consecutive_ones,

--- a/tests/generative_processes/test_transition_matrices.py
+++ b/tests/generative_processes/test_transition_matrices.py
@@ -6,6 +6,7 @@ from simplexity.generative_processes.transition_matrices import (
     days_of_week,
     even_ones,
     fanizza,
+    matching_parens,
     mess3,
     mr_name,
     no_consecutive_ones,
@@ -102,6 +103,15 @@ def test_fanizza():
     validate_ghmm_transition_matrices(transition_matrices)
     tau = jnp.ones(4)
     assert jnp.allclose(jnp.sum(transition_matrices @ tau, axis=0), tau), "Stochasticity condition not met"
+
+
+def test_matching_parens():
+    transition_matrices = matching_parens(open_probs=[1.0, 0.5, 0.5])
+    assert transition_matrices.shape == (2, 4, 4)
+    validate_hmm_transition_matrices(transition_matrices, rtol=1e-5)
+    state_transition_matrix = jnp.sum(transition_matrices, axis=0)
+    stationary_distribution = stationary_state(state_transition_matrix.T)
+    assert jnp.allclose(stationary_distribution, jnp.array([1, 2, 2, 1]) / 6)
 
 
 def test_mess3():


### PR DESCRIPTION
Expose matching-parens task in generative_processes:
- generative_processes/transition_matrices.py: add matching-parens task to HMM_MATRIX_FUNCTIONS
- tests/generative_processes/test_transition_matrices.py: add unit test

Add ability to define initial state in the yaml config of hmm processes:
- builder.py: allow for initial state to be passed in yaml config