### PR TITLE
Add LocalPytorchPersister support to S3Persister

### DIFF
--- a/simplexity/persistence/s3_persister.py
+++ b/simplexity/persistence/s3_persister.py
@@ -9,6 +9,7 @@ from botocore.exceptions import ClientError
 
 from simplexity.persistence.local_equinox_persister import LocalEquinoxPersister
 from simplexity.persistence.local_penzai_persister import LocalPenzaiPersister
+from simplexity.persistence.local_pytorch_persister import LocalPytorchPersister
 from simplexity.persistence.local_persister import LocalPersister
 from simplexity.persistence.model_persister import ModelPersister
 from simplexity.predictive_models.predictive_model import PredictiveModel
@@ -71,6 +72,9 @@ class S3Persister(ModelPersister):
             local_persister = LocalEquinoxPersister(directory=temp_dir.name)
         elif model_framework == ModelFramework.Penzai:
             local_persister = LocalPenzaiPersister(directory=temp_dir.name)
+        elif model_framework == ModelFramework.Pytorch:
+            local_persister = LocalPytorchPersister(directory=temp_dir.name)
+        
         return cls(
             bucket=bucket,
             prefix=prefix,

--- a/simplexity/predictive_models/types.py
+++ b/simplexity/predictive_models/types.py
@@ -6,3 +6,4 @@ class ModelFramework(StrEnum):
 
     Equinox = "equinox"
     Penzai = "penzai"
+    Pytorch = "pytorch"


### PR DESCRIPTION
**Summary**
This PR adds support for persisting PyTorch models on S3

**Changes**
- Adds `Pytorch` entry to `ModelFramework` enum
- Enables use of `LocalPytorchPersister` within `S3Persister`

**Testing**
- No additional tests added as it seemed unnecessary
- Existing tests all passing