### PR TITLE
Add method to log resolved configs

### DIFF
--- a/simplexity/logging/file_logger.py
+++ b/simplexity/logging/file_logger.py
@@ -21,7 +21,7 @@ class FileLogger(Logger):
         """Log config to the file."""
         with open(self.file_path, "a") as f:
             print(f"Config: {config}", file=f)
-    
+
     def log_resolved_config(self, config: DictConfig) -> None:
         """Log a resolved config to the file."""
         with open(self.file_path, "a") as f:
@@ -47,10 +47,19 @@ class FileLogger(Logger):
         """Close the logger."""
         pass
 
+
 if __name__ == "__main__":
     print("Testing FileLogger resolved config...")
     logger = FileLogger("test.log")
     print(f"Logging to {logger.file_path}")
-    logger.log_resolved_config(DictConfig({"base_value": "hello", "interpolated_value": "${base_value}_world", "nested": {"value": "${base_value}_nested"}}))
+    logger.log_resolved_config(
+        DictConfig(
+            {
+                "base_value": "hello",
+                "interpolated_value": "${base_value}_world",
+                "nested": {"value": "${base_value}_nested"},
+            }
+        )
+    )
     logger.close()
     print("Test completed! Check test.log for output.")

--- a/simplexity/logging/file_logger.py
+++ b/simplexity/logging/file_logger.py
@@ -2,7 +2,7 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
-from omegaconf import DictConfig
+from omegaconf import DictConfig, OmegaConf
 
 from simplexity.logging.logger import Logger
 
@@ -21,6 +21,12 @@ class FileLogger(Logger):
         """Log config to the file."""
         with open(self.file_path, "a") as f:
             print(f"Config: {config}", file=f)
+    
+    def log_resolved_config(self, config: DictConfig) -> None:
+        """Log a resolved config to the file."""
+        with open(self.file_path, "a") as f:
+            resolved_config = OmegaConf.to_container(config, resolve=True)
+            print(f"Resolved config: {resolved_config}", file=f)
 
     def log_metrics(self, step: int, metric_dict: Mapping[str, Any]) -> None:
         """Log metrics to the file."""
@@ -40,3 +46,11 @@ class FileLogger(Logger):
     def close(self) -> None:
         """Close the logger."""
         pass
+
+if __name__ == "__main__":
+    print("Testing FileLogger resolved config...")
+    logger = FileLogger("test.log")
+    print(f"Logging to {logger.file_path}")
+    logger.log_resolved_config(DictConfig({"base_value": "hello", "interpolated_value": "${base_value}_world", "nested": {"value": "${base_value}_nested"}}))
+    logger.close()
+    print("Test completed! Check test.log for output.")

--- a/simplexity/logging/file_logger.py
+++ b/simplexity/logging/file_logger.py
@@ -17,16 +17,11 @@ class FileLogger(Logger):
         except PermissionError as e:
             raise RuntimeError(f"Failed to create directory for logging: {e}") from e
 
-    def log_config(self, config: DictConfig) -> None:
+    def log_config(self, config: DictConfig, resolve: bool = False) -> None:
         """Log config to the file."""
         with open(self.file_path, "a") as f:
-            print(f"Config: {config}", file=f)
-
-    def log_resolved_config(self, config: DictConfig) -> None:
-        """Log a resolved config to the file."""
-        with open(self.file_path, "a") as f:
-            resolved_config = OmegaConf.to_container(config, resolve=True)
-            print(f"Resolved config: {resolved_config}", file=f)
+            _config = OmegaConf.to_container(config, resolve=resolve)
+            print(f"Config: {_config}", file=f)
 
     def log_metrics(self, step: int, metric_dict: Mapping[str, Any]) -> None:
         """Log metrics to the file."""
@@ -46,20 +41,3 @@ class FileLogger(Logger):
     def close(self) -> None:
         """Close the logger."""
         pass
-
-
-if __name__ == "__main__":
-    print("Testing FileLogger resolved config...")
-    logger = FileLogger("test.log")
-    print(f"Logging to {logger.file_path}")
-    logger.log_resolved_config(
-        DictConfig(
-            {
-                "base_value": "hello",
-                "interpolated_value": "${base_value}_world",
-                "nested": {"value": "${base_value}_nested"},
-            }
-        )
-    )
-    logger.close()
-    print("Test completed! Check test.log for output.")

--- a/simplexity/logging/logger.py
+++ b/simplexity/logging/logger.py
@@ -12,6 +12,11 @@ class Logger(ABC):
     def log_config(self, config: DictConfig) -> None:
         """Log config to the logger."""
         ...
+    
+    @abstractmethod
+    def log_resolved_config(self, config: DictConfig) -> None:
+        """Log a resolved config to the logger."""
+        ...
 
     @abstractmethod
     def log_metrics(self, step: int, metric_dict: Mapping[str, Any]) -> None:

--- a/simplexity/logging/logger.py
+++ b/simplexity/logging/logger.py
@@ -12,7 +12,7 @@ class Logger(ABC):
     def log_config(self, config: DictConfig) -> None:
         """Log config to the logger."""
         ...
-    
+
     @abstractmethod
     def log_resolved_config(self, config: DictConfig) -> None:
         """Log a resolved config to the logger."""

--- a/simplexity/logging/logger.py
+++ b/simplexity/logging/logger.py
@@ -9,13 +9,8 @@ class Logger(ABC):
     """Logs to a variety of backends."""
 
     @abstractmethod
-    def log_config(self, config: DictConfig) -> None:
+    def log_config(self, config: DictConfig, resolve: bool = False) -> None:
         """Log config to the logger."""
-        ...
-
-    @abstractmethod
-    def log_resolved_config(self, config: DictConfig) -> None:
-        """Log a resolved config to the logger."""
         ...
 
     @abstractmethod

--- a/simplexity/logging/mlflow_logger.py
+++ b/simplexity/logging/mlflow_logger.py
@@ -34,18 +34,11 @@ class MLFlowLogger(Logger):
         run = self._client.create_run(experiment_id=experiment_id, run_name=run_name)
         self._run_id = run.info.run_id
 
-    def log_config(self, config: DictConfig) -> None:
+    def log_config(self, config: DictConfig, resolve: bool = False) -> None:
         """Log config to MLflow."""
         with tempfile.TemporaryDirectory() as temp_dir:
             config_path = os.path.join(temp_dir, "config.yaml")
-            OmegaConf.save(config, config_path)
-            self._client.log_artifact(self._run_id, config_path)
-
-    def log_resolved_config(self, config: DictConfig) -> None:
-        """Log a resolved config to MLflow."""
-        with tempfile.TemporaryDirectory() as temp_dir:
-            config_path = os.path.join(temp_dir, "config_resolved.yaml")
-            OmegaConf.save(config, config_path, resolve=True)
+            OmegaConf.save(config, config_path, resolve=resolve)
             self._client.log_artifact(self._run_id, config_path)
 
     def log_metrics(self, step: int, metric_dict: Mapping[str, Any]) -> None:

--- a/simplexity/logging/mlflow_logger.py
+++ b/simplexity/logging/mlflow_logger.py
@@ -40,7 +40,7 @@ class MLFlowLogger(Logger):
             config_path = os.path.join(temp_dir, "config.yaml")
             OmegaConf.save(config, config_path)
             self._client.log_artifact(self._run_id, config_path)
-    
+
     def log_resolved_config(self, config: DictConfig) -> None:
         """Log a resolved config to MLflow."""
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/simplexity/logging/mlflow_logger.py
+++ b/simplexity/logging/mlflow_logger.py
@@ -40,6 +40,13 @@ class MLFlowLogger(Logger):
             config_path = os.path.join(temp_dir, "config.yaml")
             OmegaConf.save(config, config_path)
             self._client.log_artifact(self._run_id, config_path)
+    
+    def log_resolved_config(self, config: DictConfig) -> None:
+        """Log a resolved config to MLflow."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config_path = os.path.join(temp_dir, "config_resolved.yaml")
+            OmegaConf.save(config, config_path, resolve=True)
+            self._client.log_artifact(self._run_id, config_path)
 
     def log_metrics(self, step: int, metric_dict: Mapping[str, Any]) -> None:
         """Log metrics to MLflow."""

--- a/simplexity/logging/print_logger.py
+++ b/simplexity/logging/print_logger.py
@@ -13,7 +13,7 @@ class PrintLogger(Logger):
     def log_config(self, config: DictConfig) -> None:
         """Log config to the console."""
         pprint(f"Config: {config}")
-    
+
     def log_resolved_config(self, config: DictConfig) -> None:
         """Log a resolved config to the console."""
         resolved_config = OmegaConf.to_container(config, resolve=True)

--- a/simplexity/logging/print_logger.py
+++ b/simplexity/logging/print_logger.py
@@ -2,7 +2,7 @@ from collections.abc import Mapping
 from pprint import pprint
 from typing import Any
 
-from omegaconf import DictConfig
+from omegaconf import DictConfig, OmegaConf
 
 from simplexity.logging.logger import Logger
 
@@ -13,6 +13,11 @@ class PrintLogger(Logger):
     def log_config(self, config: DictConfig) -> None:
         """Log config to the console."""
         pprint(f"Config: {config}")
+    
+    def log_resolved_config(self, config: DictConfig) -> None:
+        """Log a resolved config to the console."""
+        resolved_config = OmegaConf.to_container(config, resolve=True)
+        pprint(f"Resolved config: {resolved_config}")
 
     def log_metrics(self, step: int, metric_dict: Mapping[str, Any]) -> None:
         """Log metrics to the console."""

--- a/simplexity/logging/print_logger.py
+++ b/simplexity/logging/print_logger.py
@@ -10,14 +10,10 @@ from simplexity.logging.logger import Logger
 class PrintLogger(Logger):
     """Logs to the console."""
 
-    def log_config(self, config: DictConfig) -> None:
+    def log_config(self, config: DictConfig, resolve: bool = False) -> None:
         """Log config to the console."""
-        pprint(f"Config: {config}")
-
-    def log_resolved_config(self, config: DictConfig) -> None:
-        """Log a resolved config to the console."""
-        resolved_config = OmegaConf.to_container(config, resolve=True)
-        pprint(f"Resolved config: {resolved_config}")
+        _config = OmegaConf.to_container(config, resolve=resolve)
+        pprint(f"Config: {_config}")
 
     def log_metrics(self, step: int, metric_dict: Mapping[str, Any]) -> None:
         """Log metrics to the console."""

--- a/tests/logging/test_file_logger.py
+++ b/tests/logging/test_file_logger.py
@@ -45,6 +45,7 @@ def test_file_logger(tmp_path: Path):
     with open(tmp_path / "test.log") as f:
         assert f.read() == EXPECTED_LOG
 
+
 def test_file_logger_with_interpolation(tmp_path: Path):
     """Test that resolved config properly resolves interpolations."""
     logger = FileLogger(str(tmp_path / "test.log"))
@@ -53,11 +54,11 @@ def test_file_logger_with_interpolation(tmp_path: Path):
     config_dict = {
         "base_value": "hello",
         "interpolated_value": "${base_value}_world",
-        "nested":{
+        "nested": {
             "value": "${base_value}_nested",
         },
     }
-    
+
     config = DictConfig(config_dict)
     logger.log_resolved_config(config)
     logger.close()

--- a/tests/logging/test_file_logger.py
+++ b/tests/logging/test_file_logger.py
@@ -6,13 +6,13 @@ from omegaconf import DictConfig
 from simplexity.logging.file_logger import FileLogger
 
 EXPECTED_LOG = """Config: {'str_param': 'str_value', 'int_param': 1, 'float_param': 1.0, 'bool_param': True}
-Resolved config: {'str_param': 'str_value', 'int_param': 1, 'float_param': 1.0, 'bool_param': True}
+Config: {'str_param': 'str_value', 'int_param': 1, 'float_param': 1.0, 'bool_param': True}
 Params: {'str_param': 'str_value', 'int_param': 1, 'float_param': 1.0, 'bool_param': True}
 Tags: {'str_tag': 'str_value', 'int_tag': 1, 'float_tag': 1.0, 'bool_tag': True}
 Metrics at step 1: {'int_metric': 1, 'float_metric': 1.0, 'jnp_metric': Array(0.1, dtype=float32, weak_type=True)}
 """
 
-EXPECTED_LOG_WITH_INTERPOLATION = """Resolved config: {'base_value': 'hello', 'interpolated_value': 'hello_world', 'nested': {'value': 'hello_nested'}}
+EXPECTED_LOG_WITH_INTERPOLATION = """Config: {'base_value': 'hello', 'interpolated_value': 'hello_world', 'nested': {'value': 'hello_nested'}}
 """
 
 
@@ -25,7 +25,7 @@ def test_file_logger(tmp_path: Path):
         "bool_param": True,
     }
     logger.log_config(DictConfig(params))
-    logger.log_resolved_config(DictConfig(params))
+    logger.log_config(DictConfig(params), resolve=True)
     logger.log_params(params)
     tags = {
         "str_tag": "str_value",
@@ -60,7 +60,7 @@ def test_file_logger_with_interpolation(tmp_path: Path):
     }
 
     config = DictConfig(config_dict)
-    logger.log_resolved_config(config)
+    logger.log_config(config, resolve=True)
     logger.close()
 
     with open(tmp_path / "test.log") as f:

--- a/tests/logging/test_file_logger.py
+++ b/tests/logging/test_file_logger.py
@@ -6,9 +6,13 @@ from omegaconf import DictConfig
 from simplexity.logging.file_logger import FileLogger
 
 EXPECTED_LOG = """Config: {'str_param': 'str_value', 'int_param': 1, 'float_param': 1.0, 'bool_param': True}
+Resolved config: {'str_param': 'str_value', 'int_param': 1, 'float_param': 1.0, 'bool_param': True}
 Params: {'str_param': 'str_value', 'int_param': 1, 'float_param': 1.0, 'bool_param': True}
 Tags: {'str_tag': 'str_value', 'int_tag': 1, 'float_tag': 1.0, 'bool_tag': True}
 Metrics at step 1: {'int_metric': 1, 'float_metric': 1.0, 'jnp_metric': Array(0.1, dtype=float32, weak_type=True)}
+"""
+
+EXPECTED_LOG_WITH_INTERPOLATION = """Resolved config: {'base_value': 'hello', 'interpolated_value': 'hello_world', 'nested': {'value': 'hello_nested'}}
 """
 
 
@@ -21,6 +25,7 @@ def test_file_logger(tmp_path: Path):
         "bool_param": True,
     }
     logger.log_config(DictConfig(params))
+    logger.log_resolved_config(DictConfig(params))
     logger.log_params(params)
     tags = {
         "str_tag": "str_value",
@@ -39,3 +44,23 @@ def test_file_logger(tmp_path: Path):
 
     with open(tmp_path / "test.log") as f:
         assert f.read() == EXPECTED_LOG
+
+def test_file_logger_with_interpolation(tmp_path: Path):
+    """Test that resolved config properly resolves interpolations."""
+    logger = FileLogger(str(tmp_path / "test.log"))
+
+    # Create a config with interpolation
+    config_dict = {
+        "base_value": "hello",
+        "interpolated_value": "${base_value}_world",
+        "nested":{
+            "value": "${base_value}_nested",
+        },
+    }
+    
+    config = DictConfig(config_dict)
+    logger.log_resolved_config(config)
+    logger.close()
+
+    with open(tmp_path / "test.log") as f:
+        assert f.read() == EXPECTED_LOG_WITH_INTERPOLATION


### PR DESCRIPTION
**Summary**
This PR adds support for logging of resolved forms of interpolatable values in configs (e.g. `${var}` becomes `hello` if `var = hello`). Note that these methods will fail if there are unassigned variables in the config.

**Changes**
Adds method to all logging classes (`Logger`, `FileLogger`, `MLFlowLogger`, and `PrintLogger`) to allow logging of resolved interpolatable values in configs.

**Testing**
Added test for the `FileLogger` class
Existing tests all passing