### PR TITLE
fix: update JAX DLPack API to remove deprecation warning

### DIFF
--- a/simplexity/utils/pytorch_utils.py
+++ b/simplexity/utils/pytorch_utils.py
@@ -27,7 +27,6 @@ def jax_to_torch(jax_array: jax.Array) -> torch.Tensor:
 
     Args:
         jax_array: JAX array to convert
-        device: Target PyTorch device (optional, will use JAX array's device if None)
 
     Returns:
         PyTorch tensor
@@ -36,8 +35,7 @@ def jax_to_torch(jax_array: jax.Array) -> torch.Tensor:
         ImportError: If JAX or PyTorch is not available
     """
     try:
-        dlpack_tensor = jax_dlpack.to_dlpack(jax_array)
-        torch_tensor = torch_dlpack.from_dlpack(dlpack_tensor)
+        torch_tensor = torch_dlpack.from_dlpack(jax_array)
         return torch_tensor
 
     except Exception as e:


### PR DESCRIPTION
The jax.dlpack.to_dlpack function was deprecated in JAX v0.6.0 and removed in v0.7.0.

Updated jax_to_torch function to pass JAX arrays directly to torch.utils.dlpack.from_dlpack, which uses the newer __dlpack__ protocol automatically.

Fixes #70

Generated with [Claude Code](https://claude.ai/code)