### PR TITLE
Add artifact and json logging functionality to all logger implementations

### DIFF
--- a/simplexity/logging/file_logger.py
+++ b/simplexity/logging/file_logger.py
@@ -126,6 +126,53 @@ class FileLogger(Logger):
                 with open(self.file_path, "a") as f:
                     print(f"Time-stepped image saved: {image_path}", file=f)
 
+    def log_artifact(self, local_path: str, artifact_path: str | None = None) -> None:
+        """Copy artifact to the log directory."""
+        import shutil
+
+        source_path = Path(local_path)
+        if not source_path.exists():
+            with open(self.file_path, "a") as f:
+                print(f"Artifact logging failed - file not found: {local_path}", file=f)
+            return
+
+        # Determine destination path
+        if artifact_path:
+            dest_path = Path(self.file_path).parent / artifact_path
+        else:
+            dest_path = Path(self.file_path).parent / source_path.name
+
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+
+        try:
+            if source_path.is_file():
+                shutil.copy2(local_path, dest_path)
+            else:
+                shutil.copytree(local_path, dest_path, dirs_exist_ok=True)
+
+            with open(self.file_path, "a") as f:
+                print(f"Artifact copied: {local_path} -> {dest_path}", file=f)
+        except Exception as e:
+            with open(self.file_path, "a") as f:
+                print(f"Failed to copy artifact: {e}", file=f)
+
+    def log_json_artifact(self, data: dict | list, artifact_name: str) -> None:
+        """Save JSON data as an artifact to the log directory."""
+        import json
+
+        json_path = Path(self.file_path).parent / artifact_name
+        json_path.parent.mkdir(parents=True, exist_ok=True)
+
+        try:
+            with open(json_path, "w") as f:
+                json.dump(data, f, indent=2)
+
+            with open(self.file_path, "a") as f:
+                print(f"JSON artifact saved: {json_path}", file=f)
+        except Exception as e:
+            with open(self.file_path, "a") as f:
+                print(f"Failed to save JSON artifact: {e}", file=f)
+
     def close(self) -> None:
         """Close the logger."""
         pass

--- a/simplexity/logging/logger.py
+++ b/simplexity/logging/logger.py
@@ -73,6 +73,27 @@ class Logger(ABC):
         ...
 
     @abstractmethod
+    def log_artifact(self, local_path: str, artifact_path: str | None = None) -> None:
+        """Log an artifact (file or directory) to the logger.
+
+        Args:
+            local_path: Path to the local file or directory to log
+            artifact_path: Optional artifact path within the experiment run.
+                          If None, uses the filename from local_path.
+        """
+        ...
+
+    @abstractmethod
+    def log_json_artifact(self, data: dict | list, artifact_name: str) -> None:
+        """Log a JSON object as an artifact to the logger.
+
+        Args:
+            data: Dictionary or list to serialize as JSON
+            artifact_name: Name for the artifact (e.g., "results.json")
+        """
+        ...
+
+    @abstractmethod
     def close(self) -> None:
         """Close the logger."""
         ...

--- a/simplexity/logging/mlflow_logger.py
+++ b/simplexity/logging/mlflow_logger.py
@@ -115,6 +115,20 @@ class MLFlowLogger(Logger):
 
         self._client.log_image(self._run_id, image, artifact_file=artifact_file, key=key, step=step, **kwargs)
 
+    def log_artifact(self, local_path: str, artifact_path: str | None = None) -> None:
+        """Log an artifact (file or directory) to MLflow."""
+        self._client.log_artifact(self._run_id, local_path, artifact_path)
+
+    def log_json_artifact(self, data: dict | list, artifact_name: str) -> None:
+        """Log a JSON object as an artifact to MLflow."""
+        import json
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            json_path = os.path.join(temp_dir, artifact_name)
+            with open(json_path, "w") as f:
+                json.dump(data, f, indent=2)
+            self._client.log_artifact(self._run_id, json_path)
+
     def close(self):
         """End the MLflow run."""
         self._client.set_terminated(self._run_id)

--- a/simplexity/logging/print_logger.py
+++ b/simplexity/logging/print_logger.py
@@ -60,6 +60,17 @@ class PrintLogger(Logger):
         else:
             print(f"[PrintLogger] Image NOT saved - would be key: {key}, step: {step} (type: {type(image).__name__})")
 
+    def log_artifact(self, local_path: str, artifact_path: str | None = None) -> None:
+        """Print artifact info to the console (no actual artifact logged)."""
+        dest_name = artifact_path if artifact_path else f"<filename from {local_path}>"
+        print(f"[PrintLogger] Artifact NOT logged - would copy: {local_path} -> {dest_name}")
+
+    def log_json_artifact(self, data: dict | list, artifact_name: str) -> None:
+        """Print JSON artifact info to the console (no actual artifact saved)."""
+        data_type = "dict" if isinstance(data, dict) else "list"
+        data_size = len(data)
+        print(f"[PrintLogger] JSON artifact NOT saved - would be: {artifact_name} ({data_type} with {data_size} items)")
+
     def close(self) -> None:
         """Close the logger."""
         pass

--- a/tests/logging/test_artifact_logging.py
+++ b/tests/logging/test_artifact_logging.py
@@ -1,0 +1,275 @@
+"""Tests for artifact logging functionality across all logger implementations."""
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from simplexity.logging.file_logger import FileLogger
+from simplexity.logging.mlflow_logger import MLFlowLogger
+from simplexity.logging.print_logger import PrintLogger
+
+
+@pytest.fixture
+def sample_json_data():
+    """Sample JSON data for testing."""
+    return {"key": "value", "number": 42, "list": [1, 2, 3]}
+
+
+@pytest.fixture
+def sample_list_data():
+    """Sample list data for testing."""
+    return [{"id": 1, "name": "test1"}, {"id": 2, "name": "test2"}]
+
+
+@pytest.fixture
+def test_artifact_file(tmp_path: Path):
+    """Create a test file to use as an artifact."""
+    test_file = tmp_path / "source" / "test_artifact.txt"
+    test_file.parent.mkdir()
+    test_file.write_text("test content")
+    return test_file
+
+
+@pytest.fixture
+def test_artifact_directory(tmp_path: Path):
+    """Create a test directory to use as an artifact."""
+    source_dir = tmp_path / "source_dir"
+    source_dir.mkdir()
+    (source_dir / "file1.txt").write_text("content1")
+    (source_dir / "file2.txt").write_text("content2")
+    return source_dir
+
+
+@pytest.fixture
+def file_logger(tmp_path: Path):
+    """Create FileLogger with temporary path."""
+    return FileLogger(str(tmp_path / "test.log"))
+
+
+@pytest.fixture
+def print_logger():
+    """Create PrintLogger."""
+    return PrintLogger()
+
+
+class TestFileLoggerArtifacts:
+    """Tests for FileLogger artifact logging."""
+
+    def test_log_artifact_copies_file(self, file_logger, test_artifact_file, tmp_path: Path):
+        """Test that log_artifact copies a file to the log directory."""
+        # Act
+        file_logger.log_artifact(str(test_artifact_file))
+        file_logger.close()
+
+        # Assert
+        copied_file = tmp_path / "test_artifact.txt"
+        assert copied_file.exists()
+        assert copied_file.read_text() == "test content"
+
+        # Verify log content
+        with open(tmp_path / "test.log") as f:
+            log_content = f.read()
+            assert "Artifact copied:" in log_content
+            assert "test_artifact.txt" in log_content
+
+    def test_log_artifact_with_custom_path(self, file_logger, tmp_path: Path):
+        """Test log_artifact with custom artifact path."""
+        # Arrange
+        test_file = tmp_path / "source.txt"
+        test_file.write_text("content")
+
+        # Act
+        file_logger.log_artifact(str(test_file), "custom/path/dest.txt")
+        file_logger.close()
+
+        # Assert
+        copied_file = tmp_path / "custom" / "path" / "dest.txt"
+        assert copied_file.exists()
+        assert copied_file.read_text() == "content"
+
+    def test_log_artifact_directory(self, file_logger, test_artifact_directory, tmp_path: Path):
+        """Test that log_artifact can copy entire directories."""
+        # Act
+        file_logger.log_artifact(str(test_artifact_directory), "copied_dir")
+        file_logger.close()
+
+        # Assert
+        copied_dir = tmp_path / "copied_dir"
+        assert copied_dir.is_dir()
+        assert (copied_dir / "file1.txt").read_text() == "content1"
+        assert (copied_dir / "file2.txt").read_text() == "content2"
+
+    def test_log_artifact_nonexistent_file(self, file_logger, tmp_path: Path):
+        """Test log_artifact with nonexistent file logs error."""
+        # Act
+        file_logger.log_artifact("/nonexistent/file.txt")
+        file_logger.close()
+
+        # Assert
+        with open(tmp_path / "test.log") as f:
+            log_content = f.read()
+            assert "Artifact logging failed - file not found" in log_content
+
+    def test_log_json_artifact_saves_json(self, file_logger, sample_json_data, tmp_path: Path):
+        """Test that log_json_artifact saves JSON data."""
+        # Act
+        file_logger.log_json_artifact(sample_json_data, "results.json")
+        file_logger.close()
+
+        # Assert
+        json_file = tmp_path / "results.json"
+        assert json_file.exists()
+
+        with open(json_file) as f:
+            loaded_data = json.load(f)
+            assert loaded_data == sample_json_data
+
+        # Verify log content
+        with open(tmp_path / "test.log") as f:
+            log_content = f.read()
+            assert "JSON artifact saved:" in log_content
+            assert "results.json" in log_content
+
+    def test_log_json_artifact_with_list(self, file_logger, sample_list_data, tmp_path: Path):
+        """Test log_json_artifact with list data."""
+        # Act
+        file_logger.log_json_artifact(sample_list_data, "data_list.json")
+        file_logger.close()
+
+        # Assert
+        json_file = tmp_path / "data_list.json"
+        assert json_file.exists()
+
+        with open(json_file) as f:
+            loaded_data = json.load(f)
+            assert loaded_data == sample_list_data
+
+
+class TestPrintLoggerArtifacts:
+    """Tests for PrintLogger artifact logging."""
+
+    def test_log_artifact_prints_info(self, print_logger, capsys):
+        """Test that log_artifact prints appropriate message."""
+        # Act
+        print_logger.log_artifact("/path/to/file.txt")
+        print_logger.close()
+
+        # Assert
+        captured = capsys.readouterr()
+        expected = (
+            "[PrintLogger] Artifact NOT logged - would copy: /path/to/file.txt -> <filename from /path/to/file.txt>"
+        )
+        assert expected in captured.out
+
+    def test_log_artifact_with_custom_path_prints_info(self, print_logger, capsys):
+        """Test log_artifact with custom path prints correct message."""
+        # Act
+        print_logger.log_artifact("/source.txt", "dest/path.txt")
+        print_logger.close()
+
+        # Assert
+        captured = capsys.readouterr()
+        expected = "[PrintLogger] Artifact NOT logged - would copy: /source.txt -> dest/path.txt"
+        assert expected in captured.out
+
+    def test_log_json_artifact_prints_info(self, print_logger, sample_json_data, capsys):
+        """Test log_json_artifact prints correct message."""
+        # Act
+        print_logger.log_json_artifact(sample_json_data, "test.json")
+        print_logger.close()
+
+        # Assert
+        captured = capsys.readouterr()
+        expected = "[PrintLogger] JSON artifact NOT saved - would be: test.json (dict with 3 items)"
+        assert expected in captured.out
+
+    def test_log_json_artifact_list_prints_info(self, print_logger, sample_list_data, capsys):
+        """Test log_json_artifact with list prints correct message."""
+        # Act
+        print_logger.log_json_artifact(sample_list_data, "list.json")
+        print_logger.close()
+
+        # Assert
+        captured = capsys.readouterr()
+        expected = "[PrintLogger] JSON artifact NOT saved - would be: list.json (list with 2 items)"
+        assert expected in captured.out
+
+
+class TestMLFlowLoggerArtifacts:
+    """Tests for MLFlowLogger artifact logging."""
+
+    @pytest.fixture(autouse=True)
+    def setup_mlflow_temp_dir(self):
+        """Set up temporary directory for MLflow tracking during tests."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            # Set MLflow tracking URI to temp directory to avoid creating mlruns/ in project
+            original_uri = os.environ.get("MLFLOW_TRACKING_URI")
+            os.environ["MLFLOW_TRACKING_URI"] = f"file://{tmp_dir}"
+            try:
+                yield
+            finally:
+                # Restore original URI
+                if original_uri is not None:
+                    os.environ["MLFLOW_TRACKING_URI"] = original_uri
+                else:
+                    os.environ.pop("MLFLOW_TRACKING_URI", None)
+
+    @pytest.fixture
+    def mock_mlflow_logger(self):
+        """Create a mocked MLFlowLogger for testing."""
+        with patch("mlflow.MlflowClient") as mock_client_class:
+            mock_client = MagicMock()
+            mock_client_class.return_value = mock_client
+            mock_client.get_experiment_by_name.return_value = None
+            mock_client.create_experiment.return_value = "exp_123"
+            mock_run = MagicMock()
+            mock_run.info.run_id = "run_456"
+            mock_client.create_run.return_value = mock_run
+
+            logger = MLFlowLogger("test_experiment")
+            yield logger, mock_client
+
+    def test_log_artifact_calls_client(self, mock_mlflow_logger):
+        """Test that log_artifact calls the MLflow client correctly."""
+        # Arrange
+        logger, mock_client = mock_mlflow_logger
+
+        # Act
+        logger.log_artifact("/path/to/file.txt", "artifacts/file.txt")
+        logger.close()
+
+        # Assert
+        mock_client.log_artifact.assert_called_once_with("run_456", "/path/to/file.txt", "artifacts/file.txt")
+
+    def test_log_artifact_without_artifact_path(self, mock_mlflow_logger):
+        """Test log_artifact without custom artifact path."""
+        # Arrange
+        logger, mock_client = mock_mlflow_logger
+
+        # Act
+        logger.log_artifact("/path/to/model.pkl")
+        logger.close()
+
+        # Assert
+        mock_client.log_artifact.assert_called_once_with("run_456", "/path/to/model.pkl", None)
+
+    def test_log_json_artifact_calls_client(self, mock_mlflow_logger, sample_json_data):
+        """Test that log_json_artifact creates temp file and calls client."""
+        # Arrange
+        logger, mock_client = mock_mlflow_logger
+
+        # Act
+        logger.log_json_artifact(sample_json_data, "metrics.json")
+        logger.close()
+
+        # Assert
+        mock_client.log_artifact.assert_called_once()
+        call_args = mock_client.log_artifact.call_args
+        assert call_args[0][0] == "run_456"  # run_id
+        assert call_args[0][1].endswith("metrics.json")  # temp file path
+        # log_json_artifact calls with only 2 args (no artifact_path)
+        assert len(call_args[0]) == 2


### PR DESCRIPTION
- Add log_artifact() and log_json_artifact() abstract methods to Logger base class
- Implement log_artifact() in MLFlowLogger using native mlflow.log_artifact()
- Implement log_json_artifact() in MLFlowLogger with automatic temp file handling
- Add FileLogger artifact support with file/directory copying to log directory
- Add PrintLogger artifact support with informational output
- Create comprehensive test suite with pytest fixtures for all logger types
- Support both existing file logging and direct JSON object serialization

🤖 Generated with [Claude Code](https://claude.ai/code)