### PR TITLE
Fix S3 persister prefix bug for proper object listing

### DIFF
--- a/simplexity/persistence/s3_persister.py
+++ b/simplexity/persistence/s3_persister.py
@@ -135,7 +135,7 @@ class S3Persister(ModelPersister):
             raise RuntimeError(f"Unexpected error saving {file_name} to S3: {e}") from e
 
     def _download_s3_objects(self, step: int) -> None:
-        prefix = f"{self.prefix}/{step}"
+        prefix = f"{self.prefix}/{step}/"
         paginator = self.s3_client.get_paginator("list_objects_v2")
         for page in paginator.paginate(Bucket=self.bucket, Prefix=prefix):
             for obj in page.get("Contents", []):

--- a/tests/persistence/s3_mocks.py
+++ b/tests/persistence/s3_mocks.py
@@ -15,7 +15,14 @@ class MockS3Paginator:
         """Paginate over the objects in an S3 bucket."""
         bucket_dir = self.root_dir / Bucket
         bucket_dir.mkdir(exist_ok=True)
-        return [{"Key": obj.name} for obj in bucket_dir.glob(f"{Prefix}/*")]
+        files = []
+        for obj in bucket_dir.rglob("*"):
+            if obj.is_file():
+                relative_path = obj.relative_to(bucket_dir)
+                key = str(relative_path)
+                if key.startswith(Prefix):
+                    files.append({"Key": key})
+        return [{"Contents": files}]
 
 
 class MockS3Client:


### PR DESCRIPTION
The S3 persister was missing a trailing slash when constructing the prefix for listing objects within a step directory. This caused AWS S3 to treat the step number as a prefix match rather than listing contents of the directory, resulting in empty results when trying to load model weights.

Also improved the mock S3 paginator to more accurately simulate real S3 prefix behavior for better test coverage.

🤖 Generated with [Claude Code](https://claude.ai/code)