### PR TITLE
Minor change of basis of RRXOR transition matrices

### DIFF
--- a/simplexity/generative_processes/transition_matrices.py
+++ b/simplexity/generative_processes/transition_matrices.py
@@ -264,7 +264,7 @@ def rrxor(pR1: float, pR2: float) -> jax.Array:
 
     Steady-state distribution = [2, 1, 1, 1, 1] / 6
     """
-    s = {"S": 0, "0": 1, "1": 2, "T": 3, "F": 4}
+    s = {"S": 0, "0": 1, "1": 2, "F": 3, "T": 4}
 
     transition_matrices = jnp.zeros((2, 5, 5))
     transition_matrices = transition_matrices.at[0, s["S"], s["0"]].set(pR1)


### PR DESCRIPTION
This PR updates the basis (hidden state ordering) for the Random-Random XOR (RRXOR) process transition matrices. The change swaps the indices of the "F" (False) and "T" (True) states in the state dictionary:

Before: {"S": 0, "0": 1, "1": 2, "T": 3, "F": 4}
After: {"S": 0, "0": 1, "1": 2, "F": 3, "T": 4}

This change orders the basis naturally when interpreting "F" and "T" as integers 0 and 1 respectively. 

The transition logic itself remains unchanged. The steady-state distribution remains valid under this reordering.