### PR TITLE
add xavier's leaky RRXOR

### DIFF
--- a/simplexity/generative_processes/transition_matrices.py
+++ b/simplexity/generative_processes/transition_matrices.py
@@ -95,11 +95,11 @@ def fanizza(alpha: float, lamb: float) -> jax.Array:
     return jnp.stack([da, db], axis=0)
 
 
-def leaky_rrxor(pR1: float, pR2: float, epsilon: float) -> jax.Array:
+def leaky_rrxor(p1: float, p2: float, epsilon: float) -> jax.Array:
     """Creates a transition matrix for the leaky RRXOR Process."""
     assert 0 <= epsilon <= 1
 
-    transition_matrices_base = rrxor(pR1, pR2)
+    transition_matrices_base = rrxor(p1, p2)
     leak = jnp.ones((2, 5, 5))
 
     transition_matrices = (1 - epsilon) * transition_matrices_base + (epsilon / 10) * leak

--- a/simplexity/generative_processes/transition_matrices.py
+++ b/simplexity/generative_processes/transition_matrices.py
@@ -95,6 +95,18 @@ def fanizza(alpha: float, lamb: float) -> jax.Array:
     return jnp.stack([da, db], axis=0)
 
 
+def leaky_rrxor(pR1: float, pR2: float, epsilon: float) -> jax.Array:
+    """Creates a transition matrix for the RRXOR Process."""
+    assert 0 <= epsilon <= 1
+
+    transition_matrices_base = rrxor(pR1, pR2)
+    leak = jnp.ones((2, 5, 5))
+
+    transition_matrices = (1 - epsilon) * transition_matrices_base + (epsilon / 10) * leak
+
+    return transition_matrices
+
+
 def matching_parens(open_probs: list[float]) -> jax.Array:
     """Creates a model for generating Matching Parentheses."""
     if len(open_probs) < 1:
@@ -357,6 +369,7 @@ HMM_MATRIX_FUNCTIONS = {
     "coin": coin,
     "days_of_week": days_of_week,
     "even_ones": even_ones,
+    "leaky_rrxor": leaky_rrxor,
     "matching_parens": matching_parens,
     "mess3": mess3,
     "mr_name": mr_name,

--- a/simplexity/generative_processes/transition_matrices.py
+++ b/simplexity/generative_processes/transition_matrices.py
@@ -96,7 +96,7 @@ def fanizza(alpha: float, lamb: float) -> jax.Array:
 
 
 def leaky_rrxor(pR1: float, pR2: float, epsilon: float) -> jax.Array:
-    """Creates a transition matrix for the RRXOR Process."""
+    """Creates a transition matrix for the leaky RRXOR Process."""
     assert 0 <= epsilon <= 1
 
     transition_matrices_base = rrxor(pR1, pR2)

--- a/tests/generative_processes/test_transition_matrices.py
+++ b/tests/generative_processes/test_transition_matrices.py
@@ -10,6 +10,7 @@ from simplexity.generative_processes.transition_matrices import (
     even_ones,
     fanizza,
     get_stationary_state,
+    leaky_rrxor,
     matching_parens,
     mess3,
     mr_name,
@@ -169,6 +170,27 @@ def test_rrxor():
     state_transition_matrix = jnp.sum(transition_matrices, axis=0)
     stationary_distribution = get_stationary_state(state_transition_matrix.T)
     assert jnp.allclose(stationary_distribution, jnp.array([2, 1, 1, 1, 1]) / 6)
+
+
+def test_leaky_rrxor():
+    """Test the leaky rrxor transition matrices."""
+    pR1, pR2, epsilon = 0.5, 0.5, 0.1
+    transition_matrices = leaky_rrxor(pR1=pR1, pR2=pR2, epsilon=epsilon)
+    assert transition_matrices.shape == (2, 5, 5)
+    validate_hmm_transition_matrices(transition_matrices)
+
+    base_matrices = rrxor(pR1, pR2)
+    leak = jnp.ones((2, 5, 5))
+    expected = (1 - epsilon) * base_matrices + (epsilon / 10) * leak
+    chex.assert_trees_all_close(transition_matrices, expected)
+
+
+def test_leaky_rrxor_zero_epsilon():
+    """Test that leaky rrxor with epsilon=0 equals regular rrxor."""
+    pR1, pR2 = 0.5, 0.5
+    leaky_matrices = leaky_rrxor(pR1=pR1, pR2=pR2, epsilon=0.0)
+    base_matrices = rrxor(pR1, pR2)
+    chex.assert_trees_all_close(leaky_matrices, base_matrices)
 
 
 def test_sns():

--- a/tests/generative_processes/test_transition_matrices.py
+++ b/tests/generative_processes/test_transition_matrices.py
@@ -174,12 +174,12 @@ def test_rrxor():
 
 def test_leaky_rrxor():
     """Test the leaky rrxor transition matrices."""
-    pR1, pR2, epsilon = 0.5, 0.5, 0.1
-    transition_matrices = leaky_rrxor(pR1=pR1, pR2=pR2, epsilon=epsilon)
+    p1, p2, epsilon = 0.5, 0.5, 0.1
+    transition_matrices = leaky_rrxor(p1=p1, p2=p2, epsilon=epsilon)
     assert transition_matrices.shape == (2, 5, 5)
     validate_hmm_transition_matrices(transition_matrices)
 
-    base_matrices = rrxor(pR1, pR2)
+    base_matrices = rrxor(p1, p2)
     leak = jnp.ones((2, 5, 5))
     expected = (1 - epsilon) * base_matrices + (epsilon / 10) * leak
     chex.assert_trees_all_close(transition_matrices, expected)
@@ -187,9 +187,9 @@ def test_leaky_rrxor():
 
 def test_leaky_rrxor_zero_epsilon():
     """Test that leaky rrxor with epsilon=0 equals regular rrxor."""
-    pR1, pR2 = 0.5, 0.5
-    leaky_matrices = leaky_rrxor(pR1=pR1, pR2=pR2, epsilon=0.0)
-    base_matrices = rrxor(pR1, pR2)
+    p1, p2 = 0.5, 0.5
+    leaky_matrices = leaky_rrxor(p1=p1, p2=p2, epsilon=0.0)
+    base_matrices = rrxor(p1, p2)
     chex.assert_trees_all_close(leaky_matrices, base_matrices)
 
 

--- a/tests/generative_processes/test_transition_matrices.py
+++ b/tests/generative_processes/test_transition_matrices.py
@@ -162,16 +162,6 @@ def test_post_quantum():
     assert jnp.isclose(transition_matrix_sum_max_eigval, 1, atol=1e-10), "Largest absolute eigenvalue is not 1"
 
 
-def test_rrxor():
-    """Test the rrxor transition matrices."""
-    transition_matrices = rrxor(p1=0.5, p2=0.5)
-    assert transition_matrices.shape == (2, 5, 5)
-    validate_hmm_transition_matrices(transition_matrices, rtol=1e-5)  # rtol=1e-6 barely fails
-    state_transition_matrix = jnp.sum(transition_matrices, axis=0)
-    stationary_distribution = get_stationary_state(state_transition_matrix.T)
-    assert jnp.allclose(stationary_distribution, jnp.array([2, 1, 1, 1, 1]) / 6)
-
-
 def test_leaky_rrxor():
     """Test the leaky rrxor transition matrices."""
     p1, p2, epsilon = 0.5, 0.5, 0.1
@@ -191,6 +181,16 @@ def test_leaky_rrxor_zero_epsilon():
     leaky_matrices = leaky_rrxor(p1=p1, p2=p2, epsilon=0.0)
     base_matrices = rrxor(p1, p2)
     chex.assert_trees_all_close(leaky_matrices, base_matrices)
+
+
+def test_rrxor():
+    """Test the rrxor transition matrices."""
+    transition_matrices = rrxor(p1=0.5, p2=0.5)
+    assert transition_matrices.shape == (2, 5, 5)
+    validate_hmm_transition_matrices(transition_matrices, rtol=1e-5)  # rtol=1e-6 barely fails
+    state_transition_matrix = jnp.sum(transition_matrices, axis=0)
+    stationary_distribution = get_stationary_state(state_transition_matrix.T)
+    assert jnp.allclose(stationary_distribution, jnp.array([2, 1, 1, 1, 1]) / 6)
 
 
 def test_sns():

--- a/tests/generative_processes/test_transition_matrices.py
+++ b/tests/generative_processes/test_transition_matrices.py
@@ -116,15 +116,26 @@ def test_fanizza():
 
 def test_leaky_rrxor():
     """Test the leaky rrxor transition matrices."""
-    p1, p2, epsilon = 0.5, 0.5, 0.1
+    vocab_size = 2
+    num_states = 5
+    p1 = 0.5
+    p2 = 0.5
+    epsilon = 0.1
     transition_matrices = leaky_rrxor(p1=p1, p2=p2, epsilon=epsilon)
-    assert transition_matrices.shape == (2, 5, 5)
+    assert transition_matrices.shape == (vocab_size, num_states, num_states)
     validate_hmm_transition_matrices(transition_matrices)
 
     base_matrices = rrxor(p1, p2)
-    leak = jnp.ones((2, 5, 5))
-    expected = (1 - epsilon) * base_matrices + (epsilon / 10) * leak
-    chex.assert_trees_all_close(transition_matrices, expected)
+    diff = jnp.abs(transition_matrices - base_matrices)
+    leak_value = 1 / (vocab_size * num_states)
+    min_diff_expected = epsilon * jnp.min(jnp.abs(base_matrices - leak_value))
+    max_diff_expected = epsilon * jnp.max(jnp.abs(base_matrices - leak_value))
+    assert jnp.allclose(jnp.min(diff), min_diff_expected, rtol=1e-5), (
+        f"Minimum difference should be approximately {min_diff_expected}"
+    )
+    assert jnp.allclose(jnp.max(diff), max_diff_expected, rtol=1e-5), (
+        f"Maximum difference should be approximately {max_diff_expected}"
+    )
 
 
 def test_leaky_rrxor_zero_epsilon():


### PR DESCRIPTION
Taking @14xp 's implementation of leaky RRXOR and creating a new branch (since the old branch is a bit stale with all the new changes).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces `leaky_rrxor` transition matrices, registers it in HMM functions, and adds unit tests validating behavior and epsilon edge case.
> 
> - **Generative Processes**:
>   - Add `leaky_rrxor(p1, p2, epsilon)` implementing a leaky variant of `rrxor` by mixing with a uniform leak.
>   - Register `"leaky_rrxor"` in `HMM_MATRIX_FUNCTIONS`.
> - **Tests**:
>   - Add `test_leaky_rrxor` to validate shape, HMM properties, and deviation from base `rrxor` per `epsilon`.
>   - Add `test_leaky_rrxor_zero_epsilon` to assert equality with `rrxor` when `epsilon=0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c9a6606e44a122808970e6b6eb2a04b3dd0215d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->