### PR TITLE
Fix resolve base config bug

### DIFF
--- a/simplexity/structured_configs/base.py
+++ b/simplexity/structured_configs/base.py
@@ -78,8 +78,8 @@ def resolve_base_config(cfg: DictConfig, *, strict: bool, seed: int | None = Non
 
     seed_tag = cfg.get("seed")
     if seed_tag is None:
-        cfg.seed = seed or 42
-    elif seed and seed_tag != seed:
+        cfg.seed = seed if seed is not None else 42
+    elif seed is not None and seed_tag != seed:
         SIMPLEXITY_LOGGER.warning("Seed tag set to '%s', but seed is '%s'. Overriding seed tag.", seed_tag, seed)
         cfg.seed = seed
 

--- a/simplexity/structured_configs/base.py
+++ b/simplexity/structured_configs/base.py
@@ -64,8 +64,8 @@ def resolve_base_config(cfg: DictConfig, *, strict: bool, seed: int | None = Non
     Args:
         cfg: A DictConfig with seed and tags fields (from Hydra).
         strict: Whether strict mode is enabled. Used to set tags.strict.
-        seed: The random seed to use. Defaults to 42.
-        device: The device to use. Defaults to "auto".
+        seed: The random seed to use. If None, defaults to 42 when config has no seed.
+        device: The device to use. If None, defaults to "auto" when config has no device.
     """
     device_tag = cfg.get("device")
     if device_tag is None:

--- a/simplexity/structured_configs/base.py
+++ b/simplexity/structured_configs/base.py
@@ -54,7 +54,7 @@ def validate_base_config(cfg: DictConfig) -> None:
 
 
 @dynamic_resolve
-def resolve_base_config(cfg: DictConfig, *, strict: bool, seed: int = 42, device: str | None = None) -> None:
+def resolve_base_config(cfg: DictConfig, *, strict: bool, seed: int | None = None, device: str | None = None) -> None:
     """Resolve the BaseConfig by setting default values and logging mismatches.
 
     This function sets default seed and strict tag values if not present in the config.
@@ -67,25 +67,21 @@ def resolve_base_config(cfg: DictConfig, *, strict: bool, seed: int = 42, device
         seed: The random seed to use. Defaults to 42.
         device: The device to use. Defaults to "auto".
     """
-    if device is None:
-        device = "auto"
-    if cfg.get("device") is None:
+    device_tag = cfg.get("device")
+    if device_tag is None:
+        cfg.device = device or "auto"
+    elif device and device_tag != device:
+        SIMPLEXITY_LOGGER.warning(
+            "Device tag set to '%s', but device is '%s'. Overriding device tag.", device_tag, device
+        )
         cfg.device = device
-    else:
-        device_tag: str = cfg.get("device")
-        if device_tag != device:
-            SIMPLEXITY_LOGGER.warning(
-                "Device tag set to '%s', but device is '%s'. Overriding device tag.", device_tag, device
-            )
-            cfg.device = device
 
-    if cfg.get("seed") is None:
+    seed_tag = cfg.get("seed")
+    if seed_tag is None:
+        cfg.seed = seed or 42
+    elif seed and seed_tag != seed:
+        SIMPLEXITY_LOGGER.warning("Seed tag set to '%s', but seed is '%s'. Overriding seed tag.", seed_tag, seed)
         cfg.seed = seed
-    else:
-        seed_tag: int = cfg.get("seed")
-        if seed_tag != seed:
-            SIMPLEXITY_LOGGER.warning("Seed tag set to '%s', but seed is '%s'. Overriding seed tag.", seed_tag, seed)
-            cfg.seed = seed
 
     if cfg.get("tags") is None:
         cfg.tags = DictConfig({"strict": str(strict).lower()})

--- a/tests/structured_configs/test_base_config.py
+++ b/tests/structured_configs/test_base_config.py
@@ -120,9 +120,9 @@ class TestResolveBaseConfig:
     def test_empty_config_with_explicit_param_values(self) -> None:
         """Test resolve_base_config with valid configs."""
         cfg = DictConfig({})
-        resolve_base_config(cfg, strict=True, seed=34, device="gpu")
+        resolve_base_config(cfg, strict=True, seed=0, device="gpu")
         assert cfg.device == "gpu"
-        assert cfg.seed == 34
+        assert cfg.seed == 0
         assert cfg.tags.strict == "true"
 
     def test_empty_config_with_default_param_values(self) -> None:
@@ -136,10 +136,10 @@ class TestResolveBaseConfig:
     def test_config_with_matching_param_values(self) -> None:
         """Test resolve_base_config preserves matching seed, strict and device values."""
         # matching values
-        cfg = DictConfig({"device": "gpu", "seed": 34, "tags": DictConfig({"strict": "true"})})
-        resolve_base_config(cfg, strict=True, seed=34, device="gpu")
+        cfg = DictConfig({"device": "gpu", "seed": 0, "tags": DictConfig({"strict": "true"})})
+        resolve_base_config(cfg, strict=True, seed=0, device="gpu")
         assert cfg.device == "gpu"
-        assert cfg.seed == 34
+        assert cfg.seed == 0
         assert cfg.tags.strict == "true"
 
     def test_config_with_non_matching_param_values(self) -> None:
@@ -147,16 +147,16 @@ class TestResolveBaseConfig:
         # non-matching values
         cfg = DictConfig({"device": "gpu", "seed": 34, "tags": DictConfig({"strict": "true"})})
         with patch("simplexity.structured_configs.base.SIMPLEXITY_LOGGER.warning") as mock_warning:
-            resolve_base_config(cfg, strict=False, seed=56, device="cpu")
+            resolve_base_config(cfg, strict=False, seed=0, device="cpu")
             mock_warning.assert_has_calls(
                 [
                     call("Device tag set to '%s', but device is '%s'. Overriding device tag.", "gpu", "cpu"),
-                    call("Seed tag set to '%s', but seed is '%s'. Overriding seed tag.", 34, 56),
+                    call("Seed tag set to '%s', but seed is '%s'. Overriding seed tag.", 34, 0),
                     call("Strict tag set to '%s', but strict mode is '%s'. Overriding strict tag.", "true", "false"),
                 ]
             )
             assert cfg.device == "cpu"
-            assert cfg.seed == 56
+            assert cfg.seed == 0
             assert cfg.tags.strict == "false"
 
     def test_config_with_no_param_values(self) -> None:

--- a/tests/structured_configs/test_base_config.py
+++ b/tests/structured_configs/test_base_config.py
@@ -134,7 +134,7 @@ class TestResolveBaseConfig:
         assert cfg.tags.strict == "false"
 
     def test_config_with_matching_param_values(self) -> None:
-        """Test resolve_base_config overrides mismatched seed and strict values."""
+        """Test resolve_base_config preserves matching seed, strict and device values."""
         # matching values
         cfg = DictConfig({"device": "gpu", "seed": 34, "tags": DictConfig({"strict": "true"})})
         resolve_base_config(cfg, strict=True, seed=34, device="gpu")
@@ -143,7 +143,7 @@ class TestResolveBaseConfig:
         assert cfg.tags.strict == "true"
 
     def test_config_with_non_matching_param_values(self) -> None:
-        """Test resolve_base_config overrides mismatched seed and strict values."""
+        """Test resolve_base_config overrides mismatched device, seed, and strict values."""
         # non-matching values
         cfg = DictConfig({"device": "gpu", "seed": 34, "tags": DictConfig({"strict": "true"})})
         with patch("simplexity.structured_configs.base.SIMPLEXITY_LOGGER.warning") as mock_warning:
@@ -160,7 +160,7 @@ class TestResolveBaseConfig:
             assert cfg.tags.strict == "false"
 
     def test_config_with_no_param_values(self) -> None:
-        """Test resolve_base_config with no param values."""
+        """Test resolve_base_config preserves existing config values when not explicitly overridden."""
         cfg = DictConfig({"device": "gpu", "seed": 34})
         resolve_base_config(cfg, strict=False)
         assert cfg.device == "gpu"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Make `seed`/`device` params optional and only default when missing; override and warn only when explicit params differ; expand and reorganize tests.
> 
> - **Config Resolution (`simplexity/structured_configs/base.py`)**
>   - `resolve_base_config` now accepts optional `seed: int | None` and `device: str | None`.
>   - Defaults applied only when corresponding config fields are absent (`seed`→`42`, `device`→`auto`).
>   - Override + warning occur only when explicit param is provided and differs from existing config.
>   - Preserves existing values when no explicit param is given.
> - **Tests (`tests/structured_configs/test_base_config.py`)**
>   - Split into `TestValidateBaseConfig` and `TestResolveBaseConfig` with clearer test cases.
>   - Added scenarios for empty configs with explicit/default params, matching/non-matching values, and preserving existing values.
>   - Updated logger warning expectations for device/seed/strict mismatches.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4dc58e49ba60a0fca6556df74e0f845a443dbc8a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->