### PR TITLE
Add CONTRIBUTING.md with PR requirements for dev and main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,96 @@
+# Contributing Guidelines
+
+This document outlines requirements and best practices for contributing code to this repository. We use a two-tier review process with different standards for `dev` and `main` branches.
+
+## Branch Strategy
+
+- **`dev`**: Integration branch for ongoing work. Code here should be structurally sound and tested, but may still be evolving.
+- **`main`**: Production-ready code. Higher bar for test coverage, implementation quality, and static analysis compliance.
+
+## Requirements by Target Branch
+
+### Merging into `dev`
+
+PRs targeting `dev` must meet the following criteria:
+
+**Testing**
+- All existing tests must pass
+- No regressions in functionality
+
+**Design**
+- Interfaces and data structures should be well-considered and expected to remain stable
+- Public APIs should be designed with future extensibility in mind
+- Avoid patterns that will require breaking changes later
+
+**Static Analysis**
+- Strive to pass formatting (`black`, `ruff format`, or equivalent)
+- Strive to pass linting (`ruff`, `flake8`, or equivalent)
+- Strive to pass type checking (`pyright`, `mypy`, or equivalent)
+- Minor violations may be accepted with justification
+
+### Merging into `main`
+
+PRs targeting `main` must meet all `dev` requirements plus:
+
+**Testing**
+- New tests required for new functionality
+- Comprehensive coverage of edge cases and failure modes
+- Coverage metrics should not decrease
+
+**Implementation**
+- Code will be scrutinized for correctness, efficiency, and maintainability
+- Algorithms and logic should be well-documented
+- Error handling must be robust
+
+**Static Analysis**
+- All checks must pass
+- Any `# type: ignore`, `# noqa`, or equivalent suppressions require explicit justification in the PR description
+- No new warnings or errors permitted
+
+## PR Process
+
+### Before Opening a PR
+
+1. Run the test suite locally: `pytest`
+2. Run static checks:
+   ```bash
+   ruff format --check .
+   ruff check .
+   pyright
+   ```
+3. Ensure your branch is up to date with the target branch
+
+### PR Description
+
+Include the following in your PR description:
+
+- **Summary**: What does this change do?
+- **Motivation**: Why is this change needed?
+- **Testing**: How was this tested?
+- **Breaking Changes**: Any breaking changes to public APIs?
+- **Suppressions** (if any): Justification for any ignored static analysis rules
+
+### Review Criteria
+
+Reviewers will evaluate:
+
+| Criterion | `dev` | `main` |
+|-----------|-------|--------|
+| Existing tests pass | Required | Required |
+| New test coverage | Encouraged | Required |
+| Interface stability | Required | Required |
+| Implementation quality | Reviewed | Scrutinized |
+| Formatting | Should pass | Must pass |
+| Linting | Should pass | Must pass |
+| Type checking | Should pass | Must pass |
+
+## Style Guidelines
+
+- Follow existing code conventions in the repository
+- Prefer explicit over implicit
+- Write docstrings for public functions and classes
+- Keep functions focused and composable
+
+## Questions?
+
+If you're unsure whether your contribution meets these standards, open a draft PR early to get feedback before investing too much time.


### PR DESCRIPTION
Add guide for contributing to `dev` and `main` branches.

Outlines our policies and best practices that PRs targeting `dev` and `main` must meet based on guidelines that @ealt suggested in discord. These original guidelines included:
- updates to dev should at least pass all existing tests, updates to main should also introduce new tests with comprehensive coverage
- updates to dev should have structure/interfaces that are well designed and expected to be stable, updates to main will also have implementations more carefully scrutinized
- updates to dev should strive to pass static checks (formatting, linting, pyright), updates to main have a more stringent standard for failing/ignoring checks
