### PR TITLE
Add simplexity-multirun CLI for parallel experiment execution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,9 @@ penzai = [
     "penzai",
 ] # Deprecated: penzai is no longer maintained.
 
+[project.scripts]
+simplexity-multirun = "simplexity.cli.run_parallel:main"
+
 [tool.ruff]
 line-length = 120
 target-version = "py312"

--- a/simplexity/cli/__init__.py
+++ b/simplexity/cli/__init__.py
@@ -1,0 +1,1 @@
+"""Command-line tools for simplexity."""

--- a/simplexity/cli/run_parallel.py
+++ b/simplexity/cli/run_parallel.py
@@ -84,12 +84,56 @@ import subprocess
 import sys
 import time
 from concurrent.futures import ProcessPoolExecutor, as_completed
+from dataclasses import dataclass
 from pathlib import Path
 
 from omegaconf import OmegaConf
 
 # Delay between starting jobs to avoid initialization race conditions
 JOB_START_DELAY_SECONDS = 5
+
+
+@dataclass(frozen=True)
+class Job:
+    """Represents a single experiment job to be executed.
+
+    Attributes:
+        script: Path to the Python script to run.
+        config_name: Hydra config name.
+        overrides: Space-separated Hydra overrides.
+        gpu_id: GPU ID to assign via CUDA_VISIBLE_DEVICES, or None for CPU-only.
+        job_num: Job number for logging and identification.
+    """
+
+    script: str
+    config_name: str
+    overrides: str
+    gpu_id: int | None
+    job_num: int
+
+    def to_cmd(self) -> list[str]:
+        """Render the full command list for this job.
+
+        Returns:
+            List of command arguments suitable for subprocess execution.
+        """
+        cmd = [
+            "uv",
+            "run",
+            "python",
+            self.script,
+            f"--config-name={self.config_name}",
+        ]
+
+        if self.overrides:
+            cmd.extend(self.overrides.split())
+
+        return cmd
+
+    @property
+    def device_str(self) -> str:
+        """Human-readable device description."""
+        return f"GPU {self.gpu_id}" if self.gpu_id is not None else "CPU"
 
 
 def load_sweep_file(path: str) -> list[str]:
@@ -149,49 +193,69 @@ def generate_override_combinations(sweeps: list[str]) -> list[str]:
     return combinations
 
 
-def run_experiment(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+def generate_jobs(
     script: str,
     config_name: str,
-    overrides: str,
-    gpu_id: int | None,
-    job_num: int,
-    dry_run: bool = False,
-) -> dict:
-    """Run a single experiment on a specific GPU or CPU.
+    sweeps: list[str],
+    overrides: list[str],
+    gpus: list[int] | None,
+) -> list[Job]:
+    """Generate a list of jobs from sweep parameters and device configuration.
+
+    This is a pure function with no side effects, making it trivially testable.
 
     Args:
         script: Path to the Python script to run.
         config_name: Hydra config name.
-        overrides: Space-separated Hydra overrides.
-        gpu_id: GPU ID to assign via CUDA_VISIBLE_DEVICES, or None for CPU-only.
-        job_num: Job number for logging.
-        dry_run: If True, print command without executing.
+        sweeps: List of sweep strings like ['a=1,2', 'b=x,y']. Should include
+            any sweeps loaded from sweep files.
+        overrides: Explicit override strings (alternative to sweeps).
+        gpus: List of GPU IDs for round-robin assignment, or None for CPU mode.
+
+    Returns:
+        List of Job objects ready for dispatch.
+    """
+    if overrides:
+        override_list = overrides
+    elif sweeps:
+        override_list = generate_override_combinations(sweeps)
+    else:
+        override_list = [""]
+
+    jobs = []
+    for i, override_str in enumerate(override_list):
+        gpu_id = gpus[i % len(gpus)] if gpus is not None else None
+        jobs.append(
+            Job(
+                script=script,
+                config_name=config_name,
+                overrides=override_str,
+                gpu_id=gpu_id,
+                job_num=i,
+            )
+        )
+
+    return jobs
+
+
+def _run_single_job(job: Job) -> dict:
+    """Run a single experiment job.
+
+    This is an internal function called by dispatch_jobs via ProcessPoolExecutor.
+
+    Args:
+        job: The Job to execute.
 
     Returns:
         Dict with job results including status, stdout, stderr.
     """
     env = os.environ.copy()
-    if gpu_id is not None:
-        env["CUDA_VISIBLE_DEVICES"] = str(gpu_id)
+    if job.gpu_id is not None:
+        env["CUDA_VISIBLE_DEVICES"] = str(job.gpu_id)
     else:
-        env["CUDA_VISIBLE_DEVICES"] = ""  # Disable GPU
+        env["CUDA_VISIBLE_DEVICES"] = ""
 
-    cmd = [
-        "uv",
-        "run",
-        "python",
-        script,
-        f"--config-name={config_name}",
-    ]
-
-    if overrides:
-        cmd.extend(overrides.split())
-
-    device_str = f"GPU {gpu_id}" if gpu_id is not None else "CPU"
-    print(f"[Job {job_num}] {device_str}: {' '.join(cmd)}")
-
-    if dry_run:
-        return {"job_num": job_num, "gpu": gpu_id, "status": "dry_run", "overrides": overrides}
+    cmd = job.to_cmd()
 
     try:
         result = subprocess.run(
@@ -205,25 +269,61 @@ def run_experiment(  # pylint: disable=too-many-arguments,too-many-positional-ar
 
         status = "success" if result.returncode == 0 else "failed"
         return {
-            "job_num": job_num,
-            "gpu": gpu_id,
+            "job_num": job.job_num,
+            "gpu": job.gpu_id,
             "status": status,
             "returncode": result.returncode,
-            "overrides": overrides,
+            "overrides": job.overrides,
             "stdout": result.stdout[-2000:] if result.stdout else "",
             "stderr": result.stderr[-2000:] if result.stderr else "",
         }
     except Exception as e:  # noqa: BLE001  # pylint: disable=broad-exception-caught
         return {
-            "job_num": job_num,
-            "gpu": gpu_id,
+            "job_num": job.job_num,
+            "gpu": job.gpu_id,
             "status": "error",
             "error": str(e),
-            "overrides": overrides,
+            "overrides": job.overrides,
         }
 
 
-def main() -> None:  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
+def dispatch_jobs(jobs: list[Job], max_parallel: int) -> list[dict]:
+    """Execute jobs in parallel with staggered starts.
+
+    Args:
+        jobs: List of Job objects to execute.
+        max_parallel: Maximum number of jobs to run concurrently.
+
+    Returns:
+        List of result dictionaries, one per job.
+    """
+    results = []
+
+    with ProcessPoolExecutor(max_workers=max_parallel) as executor:
+        futures = {}
+
+        for i, job in enumerate(jobs):
+            if i > 0:
+                time.sleep(JOB_START_DELAY_SECONDS)
+
+            print(f"[Job {job.job_num}] {job.device_str}: {' '.join(job.to_cmd())}")
+            future = executor.submit(_run_single_job, job)
+            futures[future] = job.job_num
+
+        for future in as_completed(futures):
+            result = future.result()
+            results.append(result)
+            status_symbol = "\u2713" if result["status"] == "success" else "\u2717"
+            device_str = f"GPU {result['gpu']}" if result["gpu"] is not None else "CPU"
+            print(f"[Job {result['job_num']}] {status_symbol} {device_str}: {result['status']}")
+
+            if result["status"] == "failed":
+                print(f"  stderr: {result.get('stderr', '')[:500]}")
+
+    return results
+
+
+def main() -> None:
     """Main entry point for the CLI."""
     parser = argparse.ArgumentParser(
         description="Run multiple Hydra experiments in parallel across GPUs",
@@ -320,65 +420,34 @@ def main() -> None:  # pylint: disable=too-many-locals,too-many-branches,too-man
             "  simplexity-multirun run.py -c config --cpu --workers 4 --sweep 'seed=1,2,3,4'"
         )
 
-    # Collect sweep parameters from --sweep and --sweep-file
-    all_sweeps = list(args.sweep)  # Copy to avoid modifying args
+    # Phase 1: Generate jobs (pure, no I/O except sweep file loading)
+    all_sweeps = list(args.sweep)
     if args.sweep_file:
         all_sweeps.extend(load_sweep_file(args.sweep_file))
 
-    # Generate list of override strings
-    if args.overrides:
-        override_list = args.overrides
-    elif all_sweeps:
-        override_list = generate_override_combinations(all_sweeps)
-    else:
-        override_list = [""]  # Single run with no overrides
+    jobs = generate_jobs(
+        script=args.script,
+        config_name=args.config_name,
+        sweeps=all_sweeps,
+        overrides=args.overrides,
+        gpus=gpus,
+    )
 
-    n_jobs = len(override_list)
+    n_jobs = len(jobs)
     max_parallel = args.max_parallel or n_workers
 
     print(f"Running {n_jobs} experiments across {device_desc}")
     print(f"Max parallel: {max_parallel}")
     print()
 
-    # Assign devices round-robin (GPU IDs or None for CPU)
-    jobs = []
-    for i, overrides in enumerate(override_list):
-        if gpus is not None:
-            gpu_id = gpus[i % len(gpus)]
-        else:
-            gpu_id = None  # CPU mode
-        jobs.append((args.script, args.config_name, overrides, gpu_id, i))
+    # Handle dry-run: print commands and exit before dispatch
+    if args.dry_run:
+        for job in jobs:
+            print(f"[Job {job.job_num}] {job.device_str}: {' '.join(job.to_cmd())}")
+        return
 
-    # Run in parallel with staggered starts
-    results = []
-    with ProcessPoolExecutor(max_workers=max_parallel) as executor:
-        futures = {}
-
-        # Submit jobs with delay between starts to avoid race conditions
-        for i, job in enumerate(jobs):
-            if i > 0 and not args.dry_run:
-                time.sleep(JOB_START_DELAY_SECONDS)
-
-            future = executor.submit(
-                run_experiment,
-                script=job[0],
-                config_name=job[1],
-                overrides=job[2],
-                gpu_id=job[3],
-                job_num=job[4],
-                dry_run=args.dry_run,
-            )
-            futures[future] = job[4]
-
-        for future in as_completed(futures):
-            result = future.result()
-            results.append(result)
-            status_symbol = "\u2713" if result["status"] == "success" else "\u2717"
-            device_str = f"GPU {result['gpu']}" if result["gpu"] is not None else "CPU"
-            print(f"[Job {result['job_num']}] {status_symbol} {device_str}: {result['status']}")
-
-            if result["status"] == "failed" and not args.dry_run:
-                print(f"  stderr: {result.get('stderr', '')[:500]}")
+    # Phase 2: Dispatch jobs (handles all subprocess/parallelism complexity)
+    results = dispatch_jobs(jobs, max_parallel)
 
     # Summary
     print()

--- a/simplexity/cli/run_parallel.py
+++ b/simplexity/cli/run_parallel.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python
+"""Run multiple Hydra experiments in parallel across GPUs or CPU.
+
+simplexity-multirun is a CLI tool for running multiple Hydra experiments in
+parallel with proper device isolation. It's a simpler alternative to Ray or
+Hydra's joblib launcher when you just need to run experiments on a single machine.
+
+How It Works
+------------
+Each experiment runs in a separate subprocess with CUDA_VISIBLE_DEVICES set to
+ensure exclusive GPU access. Jobs are assigned to devices round-robin and started
+with a 5-second stagger to avoid initialization race conditions.
+
+Device Modes
+------------
+GPU Mode (--gpus):
+    Specify which GPUs to use. Each job gets exclusive access to one GPU.
+    Jobs are distributed round-robin across the specified GPUs.
+
+    Example: --gpus 0,1 with 4 jobs -> Job0:GPU0, Job1:GPU1, Job2:GPU0, Job3:GPU1
+
+CPU Mode (--cpu --workers N):
+    Run without GPU acceleration. Specify number of parallel workers.
+    Sets CUDA_VISIBLE_DEVICES="" to disable GPU for all jobs.
+
+Sweep Modes
+-----------
+--sweep (Cartesian Product):
+    Generate all combinations of parameters. Can specify multiple times.
+
+    Example: --sweep 'a=1,2' --sweep 'b=x,y'
+    Generates: a=1 b=x, a=1 b=y, a=2 b=x, a=2 b=y (4 jobs)
+
+--sweep-file (Config File):
+    Load sweep parameters from a YAML file. Can be combined with --sweep.
+
+    Example file (sweeps/my_experiment.yaml):
+        seed: [1, 2, 3, 4]
+        model.lr: [0.01, 0.001]
+
+    Example: --sweep-file sweeps/my_experiment.yaml
+    Generates: 4 x 2 = 8 jobs (cartesian product)
+
+--overrides (Explicit List):
+    Run specific override strings. Each string is one job.
+
+    Example: --overrides 'seed=1 lr=0.01' 'seed=2 lr=0.001'
+    Generates: 2 jobs with those exact overrides
+
+Usage Examples
+--------------
+    # Basic sweep across 2 GPUs
+    simplexity-multirun run.py -c train_config --gpus 0,1 --sweep 'seed=1,2,3,4'
+
+    # Load sweep params from a YAML file
+    simplexity-multirun run.py -c train_config --gpus 0,1 --sweep-file sweeps/experiment.yaml
+
+    # CPU-only mode with 4 parallel workers
+    simplexity-multirun run.py -c train_config --cpu --workers 4 --sweep 'seed=1,2,3,4'
+
+    # Cartesian product: 2x2 = 4 experiments
+    simplexity-multirun run.py -c train_config --gpus 0,1,2,3 \\
+        --sweep 'model.n_heads=1,2' \\
+        --sweep 'model.n_layers=1,2'
+
+    # Limit parallelism (e.g., 4 GPUs but only 2 jobs at a time)
+    simplexity-multirun run.py -c train_config --gpus 0,1,2,3 --max-parallel 2 --sweep 'seed=1,2,3,4'
+
+    # Dry run to preview commands without executing
+    simplexity-multirun run.py -c train_config --gpus 0,1 --sweep 'seed=1,2' --dry-run
+
+Why Not Ray/Joblib?
+-------------------
+- No package shipping or virtual environment creation
+- Simple subprocess isolation - easy to debug
+- No complex configuration or runtime environments
+- Works reliably for single-machine multi-GPU setups
+"""
+
+import argparse
+import itertools
+import os
+import subprocess
+import sys
+import time
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from pathlib import Path
+
+from omegaconf import OmegaConf
+
+# Delay between starting jobs to avoid initialization race conditions
+JOB_START_DELAY_SECONDS = 5
+
+
+def load_sweep_file(path: str) -> list[str]:
+    """Load sweep parameters from a YAML file.
+
+    The file should contain parameter names as keys and lists of values:
+
+        seed: [1, 2, 3, 4]
+        model.lr: [0.01, 0.001]
+
+    Args:
+        path: Path to the sweep YAML file.
+
+    Returns:
+        List of sweep strings like ['seed=1,2,3,4', 'model.lr=0.01,0.001']
+    """
+    cfg = OmegaConf.load(path)
+    sweeps = []
+    for key, values in cfg.items():
+        # Convert OmegaConf types to Python types
+        values = OmegaConf.to_object(values) if OmegaConf.is_config(values) else values
+        if isinstance(values, (list, tuple)):
+            values_str = ",".join(str(v) for v in values)
+        else:
+            values_str = str(values)
+        sweeps.append(f"{key}={values_str}")
+    return sweeps
+
+
+def parse_sweep_param(sweep_str: str) -> tuple[str, list[str]]:
+    """Parse a sweep parameter like 'param=1,2,3' into (param, [1, 2, 3])."""
+    key, values = sweep_str.split("=", 1)
+    return key, [v.strip() for v in values.split(",")]
+
+
+def generate_override_combinations(sweeps: list[str]) -> list[str]:
+    """Generate all combinations of sweep parameters (cartesian product).
+
+    Args:
+        sweeps: List of sweep strings like ['a=1,2', 'b=x,y']
+
+    Returns:
+        List of override strings like ['a=1 b=x', 'a=1 b=y', 'a=2 b=x', 'a=2 b=y']
+    """
+    if not sweeps:
+        return [""]
+
+    parsed = [parse_sweep_param(s) for s in sweeps]
+    keys = [p[0] for p in parsed]
+    value_lists = [p[1] for p in parsed]
+
+    combinations = []
+    for values in itertools.product(*value_lists):
+        override = " ".join(f"{k}={v}" for k, v in zip(keys, values))
+        combinations.append(override)
+
+    return combinations
+
+
+def run_experiment(
+    script: str,
+    config_name: str,
+    overrides: str,
+    gpu_id: int | None,
+    job_num: int,
+    dry_run: bool = False,
+) -> dict:
+    """Run a single experiment on a specific GPU or CPU.
+
+    Args:
+        script: Path to the Python script to run.
+        config_name: Hydra config name.
+        overrides: Space-separated Hydra overrides.
+        gpu_id: GPU ID to assign via CUDA_VISIBLE_DEVICES, or None for CPU-only.
+        job_num: Job number for logging.
+        dry_run: If True, print command without executing.
+
+    Returns:
+        Dict with job results including status, stdout, stderr.
+    """
+    env = os.environ.copy()
+    if gpu_id is not None:
+        env["CUDA_VISIBLE_DEVICES"] = str(gpu_id)
+    else:
+        env["CUDA_VISIBLE_DEVICES"] = ""  # Disable GPU
+
+    cmd = [
+        "uv",
+        "run",
+        "python",
+        script,
+        f"--config-name={config_name}",
+    ]
+
+    if overrides:
+        cmd.extend(overrides.split())
+
+    device_str = f"GPU {gpu_id}" if gpu_id is not None else "CPU"
+    print(f"[Job {job_num}] {device_str}: {' '.join(cmd)}")
+
+    if dry_run:
+        return {"job_num": job_num, "gpu": gpu_id, "status": "dry_run", "overrides": overrides}
+
+    try:
+        result = subprocess.run(
+            cmd,
+            env=env,
+            cwd=Path.cwd(),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        status = "success" if result.returncode == 0 else "failed"
+        return {
+            "job_num": job_num,
+            "gpu": gpu_id,
+            "status": status,
+            "returncode": result.returncode,
+            "overrides": overrides,
+            "stdout": result.stdout[-2000:] if result.stdout else "",
+            "stderr": result.stderr[-2000:] if result.stderr else "",
+        }
+    except Exception as e:  # noqa: BLE001
+        return {
+            "job_num": job_num,
+            "gpu": gpu_id,
+            "status": "error",
+            "error": str(e),
+            "overrides": overrides,
+        }
+
+
+def main() -> None:
+    """Main entry point for the CLI."""
+    parser = argparse.ArgumentParser(
+        description="Run multiple Hydra experiments in parallel across GPUs",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "script",
+        help="Path to the run script (e.g., experiments/training/run.py)",
+    )
+    parser.add_argument(
+        "--config-name",
+        "-c",
+        required=True,
+        help="Hydra config name (e.g., train_small)",
+    )
+    parser.add_argument(
+        "--gpus",
+        "-g",
+        default=None,
+        help="Comma-separated GPU IDs to use (e.g., '0,1,2,3')",
+    )
+    parser.add_argument(
+        "--cpu",
+        action="store_true",
+        help="Run on CPU only (disables GPU)",
+    )
+    parser.add_argument(
+        "--workers",
+        "-w",
+        type=int,
+        default=None,
+        help="Number of parallel workers (required with --cpu, optional otherwise)",
+    )
+    parser.add_argument(
+        "--sweep",
+        "-s",
+        action="append",
+        default=[],
+        help="Sweep parameter (e.g., 'seed=1,2,3'). Can specify multiple times for cartesian product.",
+    )
+    parser.add_argument(
+        "--sweep-file",
+        "-f",
+        default=None,
+        help="Path to YAML file containing sweep parameters.",
+    )
+    parser.add_argument(
+        "--overrides",
+        "-o",
+        nargs="*",
+        default=[],
+        help="Explicit override strings to run (alternative to --sweep)",
+    )
+    parser.add_argument(
+        "--max-parallel",
+        "-p",
+        type=int,
+        default=None,
+        help="Max parallel jobs (default: number of GPUs)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        "-n",
+        action="store_true",
+        help="Print commands without executing",
+    )
+
+    args = parser.parse_args()
+
+    # Determine devices (GPUs or CPU workers)
+    if args.cpu:
+        if args.workers is None:
+            parser.error("--workers is required when using --cpu")
+        gpus = None
+        n_workers = args.workers
+        device_desc = f"{n_workers} CPU workers"
+    elif args.gpus:
+        gpus = [int(g.strip()) for g in args.gpus.split(",")]
+        n_workers = args.workers or len(gpus)
+        device_desc = f"GPUs {gpus}"
+    else:
+        parser.error(
+            "You must specify devices to use.\n\n"
+            "Options:\n"
+            "  --gpus 0,1,2,3    Run on specific GPUs (comma-separated IDs)\n"
+            "  --cpu --workers 4 Run on CPU only with N parallel workers\n\n"
+            "Examples:\n"
+            "  simplexity-multirun run.py -c config --gpus 0,1 --sweep 'seed=1,2,3,4'\n"
+            "  simplexity-multirun run.py -c config --cpu --workers 4 --sweep 'seed=1,2,3,4'"
+        )
+
+    # Collect sweep parameters from --sweep and --sweep-file
+    all_sweeps = list(args.sweep)  # Copy to avoid modifying args
+    if args.sweep_file:
+        all_sweeps.extend(load_sweep_file(args.sweep_file))
+
+    # Generate list of override strings
+    if args.overrides:
+        override_list = args.overrides
+    elif all_sweeps:
+        override_list = generate_override_combinations(all_sweeps)
+    else:
+        override_list = [""]  # Single run with no overrides
+
+    n_jobs = len(override_list)
+    max_parallel = args.max_parallel or n_workers
+
+    print(f"Running {n_jobs} experiments across {device_desc}")
+    print(f"Max parallel: {max_parallel}")
+    print()
+
+    # Assign devices round-robin (GPU IDs or None for CPU)
+    jobs = []
+    for i, overrides in enumerate(override_list):
+        if gpus is not None:
+            gpu_id = gpus[i % len(gpus)]
+        else:
+            gpu_id = None  # CPU mode
+        jobs.append((args.script, args.config_name, overrides, gpu_id, i))
+
+    # Run in parallel with staggered starts
+    results = []
+    with ProcessPoolExecutor(max_workers=max_parallel) as executor:
+        futures = {}
+
+        # Submit jobs with delay between starts to avoid race conditions
+        for i, job in enumerate(jobs):
+            if i > 0 and not args.dry_run:
+                time.sleep(JOB_START_DELAY_SECONDS)
+
+            future = executor.submit(
+                run_experiment,
+                script=job[0],
+                config_name=job[1],
+                overrides=job[2],
+                gpu_id=job[3],
+                job_num=job[4],
+                dry_run=args.dry_run,
+            )
+            futures[future] = job[4]
+
+        for future in as_completed(futures):
+            result = future.result()
+            results.append(result)
+            status_symbol = "\u2713" if result["status"] == "success" else "\u2717"
+            device_str = f"GPU {result['gpu']}" if result["gpu"] is not None else "CPU"
+            print(f"[Job {result['job_num']}] {status_symbol} {device_str}: {result['status']}")
+
+            if result["status"] == "failed" and not args.dry_run:
+                print(f"  stderr: {result.get('stderr', '')[:500]}")
+
+    # Summary
+    print()
+    print("=" * 60)
+    successes = sum(1 for r in results if r["status"] == "success")
+    failures = sum(1 for r in results if r["status"] == "failed")
+    print(f"Complete: {successes} succeeded, {failures} failed out of {n_jobs} jobs")
+
+    if failures > 0:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/simplexity/cli/run_parallel.py
+++ b/simplexity/cli/run_parallel.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""Run multiple Hydra experiments in parallel across GPUs or CPU.
+r"""Run multiple Hydra experiments in parallel across GPUs or CPU.
 
 simplexity-multirun is a CLI tool for running multiple Hydra experiments in
 parallel with proper device isolation. It's a simpler alternative to Ray or
@@ -143,13 +143,13 @@ def generate_override_combinations(sweeps: list[str]) -> list[str]:
 
     combinations = []
     for values in itertools.product(*value_lists):
-        override = " ".join(f"{k}={v}" for k, v in zip(keys, values))
+        override = " ".join(f"{k}={v}" for k, v in zip(keys, values, strict=True))
         combinations.append(override)
 
     return combinations
 
 
-def run_experiment(
+def run_experiment(  # pylint: disable=too-many-arguments,too-many-positional-arguments
     script: str,
     config_name: str,
     overrides: str,
@@ -213,7 +213,7 @@ def run_experiment(
             "stdout": result.stdout[-2000:] if result.stdout else "",
             "stderr": result.stderr[-2000:] if result.stderr else "",
         }
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:  # noqa: BLE001  # pylint: disable=broad-exception-caught
         return {
             "job_num": job_num,
             "gpu": gpu_id,
@@ -223,7 +223,7 @@ def run_experiment(
         }
 
 
-def main() -> None:
+def main() -> None:  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
     """Main entry point for the CLI."""
     parser = argparse.ArgumentParser(
         description="Run multiple Hydra experiments in parallel across GPUs",
@@ -295,6 +295,10 @@ def main() -> None:
     args = parser.parse_args()
 
     # Determine devices (GPUs or CPU workers)
+    gpus: list[int] | None = None
+    n_workers: int = 0
+    device_desc: str = ""
+
     if args.cpu:
         if args.workers is None:
             parser.error("--workers is required when using --cpu")

--- a/tests/cli/test_run_parallel.py
+++ b/tests/cli/test_run_parallel.py
@@ -9,6 +9,7 @@ class TestJob:
     """Tests for the Job dataclass."""
 
     def test_to_cmd_without_overrides(self) -> None:
+        """Verify to_cmd() produces correct command without overrides."""
         job = Job(
             script="train.py",
             config_name="config",
@@ -19,6 +20,7 @@ class TestJob:
         assert job.to_cmd() == ["uv", "run", "python", "train.py", "--config-name=config"]
 
     def test_to_cmd_with_overrides(self) -> None:
+        """Verify to_cmd() appends overrides to the command."""
         job = Job(
             script="train.py",
             config_name="config",
@@ -37,10 +39,12 @@ class TestJob:
         ]
 
     def test_device_str_gpu(self) -> None:
+        """Verify device_str shows GPU ID when gpu_id is set."""
         job = Job(script="train.py", config_name="config", overrides="", gpu_id=2, job_num=0)
         assert job.device_str == "GPU 2"
 
     def test_device_str_cpu(self) -> None:
+        """Verify device_str shows CPU when gpu_id is None."""
         job = Job(script="train.py", config_name="config", overrides="", gpu_id=None, job_num=0)
         assert job.device_str == "CPU"
 

--- a/tests/cli/test_run_parallel.py
+++ b/tests/cli/test_run_parallel.py
@@ -1,0 +1,187 @@
+"""Tests for the run_parallel CLI module."""
+
+import pytest
+
+from simplexity.cli.run_parallel import Job, generate_jobs
+
+
+class TestJob:
+    """Tests for the Job dataclass."""
+
+    def test_to_cmd_without_overrides(self) -> None:
+        job = Job(
+            script="train.py",
+            config_name="config",
+            overrides="",
+            gpu_id=0,
+            job_num=0,
+        )
+        assert job.to_cmd() == ["uv", "run", "python", "train.py", "--config-name=config"]
+
+    def test_to_cmd_with_overrides(self) -> None:
+        job = Job(
+            script="train.py",
+            config_name="config",
+            overrides="seed=42 lr=0.01",
+            gpu_id=0,
+            job_num=0,
+        )
+        assert job.to_cmd() == [
+            "uv",
+            "run",
+            "python",
+            "train.py",
+            "--config-name=config",
+            "seed=42",
+            "lr=0.01",
+        ]
+
+    def test_device_str_gpu(self) -> None:
+        job = Job(script="train.py", config_name="config", overrides="", gpu_id=2, job_num=0)
+        assert job.device_str == "GPU 2"
+
+    def test_device_str_cpu(self) -> None:
+        job = Job(script="train.py", config_name="config", overrides="", gpu_id=None, job_num=0)
+        assert job.device_str == "CPU"
+
+
+class TestGenerateJobs:
+    """Tests for the generate_jobs function."""
+
+    def test_gpu_round_robin_assignment(self) -> None:
+        """Verify GPUs are assigned round-robin across jobs."""
+        jobs = generate_jobs(
+            script="train.py",
+            config_name="config",
+            sweeps=["seed=1,2,3,4,5,6"],
+            overrides=[],
+            gpus=[0, 1],
+        )
+
+        assert len(jobs) == 6
+        assert [job.gpu_id for job in jobs] == [0, 1, 0, 1, 0, 1]
+
+    def test_gpu_round_robin_with_three_gpus(self) -> None:
+        """Verify round-robin with 3 GPUs and 5 jobs."""
+        jobs = generate_jobs(
+            script="train.py",
+            config_name="config",
+            sweeps=["seed=1,2,3,4,5"],
+            overrides=[],
+            gpus=[0, 2, 4],
+        )
+
+        assert len(jobs) == 5
+        assert [job.gpu_id for job in jobs] == [0, 2, 4, 0, 2]
+
+    def test_cpu_mode_assigns_none(self) -> None:
+        """Verify CPU mode assigns None for all gpu_ids."""
+        jobs = generate_jobs(
+            script="train.py",
+            config_name="config",
+            sweeps=["seed=1,2,3"],
+            overrides=[],
+            gpus=None,
+        )
+
+        assert len(jobs) == 3
+        assert all(job.gpu_id is None for job in jobs)
+
+    def test_sweep_cartesian_product(self) -> None:
+        """Verify sweeps produce cartesian product of overrides."""
+        jobs = generate_jobs(
+            script="train.py",
+            config_name="config",
+            sweeps=["a=1,2", "b=x,y"],
+            overrides=[],
+            gpus=[0],
+        )
+
+        assert len(jobs) == 4
+        overrides = [job.overrides for job in jobs]
+        assert overrides == ["a=1 b=x", "a=1 b=y", "a=2 b=x", "a=2 b=y"]
+
+    def test_sweep_single_param(self) -> None:
+        """Verify single sweep parameter generates correct jobs."""
+        jobs = generate_jobs(
+            script="train.py",
+            config_name="config",
+            sweeps=["seed=1,2,3"],
+            overrides=[],
+            gpus=[0, 1],
+        )
+
+        assert len(jobs) == 3
+        assert [job.overrides for job in jobs] == ["seed=1", "seed=2", "seed=3"]
+
+    def test_explicit_overrides_used_instead_of_sweeps(self) -> None:
+        """Verify explicit overrides take precedence over sweeps."""
+        jobs = generate_jobs(
+            script="train.py",
+            config_name="config",
+            sweeps=["seed=1,2,3"],
+            overrides=["custom=a", "custom=b"],
+            gpus=[0],
+        )
+
+        assert len(jobs) == 2
+        assert [job.overrides for job in jobs] == ["custom=a", "custom=b"]
+
+    def test_no_sweeps_or_overrides_creates_single_job(self) -> None:
+        """Verify empty sweeps and overrides creates one job with empty overrides."""
+        jobs = generate_jobs(
+            script="train.py",
+            config_name="config",
+            sweeps=[],
+            overrides=[],
+            gpus=[0],
+        )
+
+        assert len(jobs) == 1
+        assert jobs[0].overrides == ""
+
+    def test_job_numbers_sequential(self) -> None:
+        """Verify job numbers are assigned sequentially starting from 0."""
+        jobs = generate_jobs(
+            script="train.py",
+            config_name="config",
+            sweeps=["seed=1,2,3,4"],
+            overrides=[],
+            gpus=[0, 1],
+        )
+
+        assert [job.job_num for job in jobs] == [0, 1, 2, 3]
+
+    def test_script_and_config_propagated(self) -> None:
+        """Verify script and config_name are correctly set on all jobs."""
+        jobs = generate_jobs(
+            script="experiments/run.py",
+            config_name="my_config",
+            sweeps=["seed=1,2"],
+            overrides=[],
+            gpus=[0],
+        )
+
+        assert all(job.script == "experiments/run.py" for job in jobs)
+        assert all(job.config_name == "my_config" for job in jobs)
+
+    @pytest.mark.parametrize(
+        ("sweeps", "expected_count"),
+        [
+            (["a=1,2,3"], 3),
+            (["a=1,2", "b=1,2"], 4),
+            (["a=1,2", "b=1,2,3"], 6),
+            (["a=1,2", "b=1,2", "c=1,2"], 8),
+        ],
+    )
+    def test_cartesian_product_counts(self, sweeps: list[str], expected_count: int) -> None:
+        """Verify correct number of jobs for various cartesian product sizes."""
+        jobs = generate_jobs(
+            script="train.py",
+            config_name="config",
+            sweeps=sweeps,
+            overrides=[],
+            gpus=[0],
+        )
+
+        assert len(jobs) == expected_count


### PR DESCRIPTION
## Summary

This PR adds `simplexity-multirun`, a new CLI tool for running multiple Hydra experiments in parallel across GPUs or CPU workers. It provides a simpler alternative to Ray or Hydra's joblib launcher for single-machine multi-GPU setups.

## Motivation

We encountered several issues with existing parallel execution solutions:

- **Ray**: Complex setup, package shipping issues (2.7GB packages), virtual environment creation on workers, CUDA detection problems, and "Failed to log source script" errors due to serialization
- **Hydra joblib launcher**: GPU contention errors (cuSolver internal error) when multiple jobs tried to use the same GPU

We needed something simpler that:
1. Provides proper GPU isolation via `CUDA_VISIBLE_DEVICES`
2. Uses subprocess isolation (no serialization issues)
3. Works reliably without complex configuration
4. Supports both GPU and CPU-only modes

## Features

### Device Modes

**GPU Mode (`--gpus`)**
```bash
simplexity-multirun run.py -c config --gpus 0,1,2,3 --sweep 'seed=1,2,3,4'
```
- Each job gets exclusive GPU access via `CUDA_VISIBLE_DEVICES`
- Jobs distributed round-robin across specified GPUs

**CPU Mode (`--cpu --workers N`)**
```bash
simplexity-multirun run.py -c config --cpu --workers 4 --sweep 'seed=1,2,3,4'
```
- Sets `CUDA_VISIBLE_DEVICES=""` to disable GPU
- Specify number of parallel workers explicitly

### Sweep Modes

**CLI Sweeps (`--sweep`)**
```bash
simplexity-multirun run.py -c config --gpus 0,1 \
    --sweep 'seed=1,2,3,4' \
    --sweep 'model.lr=0.01,0.001'
```
- Generates cartesian product of all sweep parameters
- Can specify multiple `--sweep` flags

**Config File Sweeps (`--sweep-file`)**
```yaml
# sweeps/my_experiment.yaml
seed: [1, 2, 3, 4]
model.lr: [0.01, 0.001]
```
```bash
simplexity-multirun run.py -c config --gpus 0,1 --sweep-file sweeps/my_experiment.yaml
```
- Load sweep parameters from YAML file
- Can combine with `--sweep` for additional parameters

**Explicit Overrides (`--overrides`)**
```bash
simplexity-multirun run.py -c config --gpus 0,1 \
    --overrides 'seed=1 lr=0.01' 'seed=2 lr=0.001'
```
- Run specific override combinations (no cartesian product)

### Other Features

- **Dry run mode** (`--dry-run`): Preview commands without executing
- **Staggered starts**: 5-second delay between job starts to avoid initialization race conditions
- **Parallelism control** (`--max-parallel`): Limit concurrent jobs even with more GPUs available
- **Verbose help**: Run `simplexity-multirun --help` for full documentation

## Design Decisions

1. **Subprocess isolation over threading/multiprocessing**: Each experiment runs as a completely separate process via `subprocess.run()`. This avoids shared state issues and makes debugging easier.

2. **Explicit device specification required**: Users must specify `--gpus` or `--cpu --workers`. We intentionally don't auto-detect GPUs to avoid accidentally using all GPUs on a shared machine.

3. **5-second stagger between job starts**: Prevents race conditions during CUDA initialization or MLflow logging setup.

4. **Separate sweep file format**: We use a simple YAML format for `--sweep-file` rather than trying to parse Hydra's `hydra.sweeper.params` config, which would require full Hydra config composition and be fragile.

5. **CLI name `simplexity-multirun`**: Matches Hydra's `-m` / `--multirun` terminology while being clearly part of the simplexity ecosystem.

## Usage Examples

```bash
# Basic GPU sweep
simplexity-multirun run.py -c train_config --gpus 0,1 --sweep 'seed=1,2,3,4'

# CPU-only mode
simplexity-multirun run.py -c train_config --cpu --workers 4 --sweep 'seed=1,2,3,4'

# Load sweeps from config file
simplexity-multirun run.py -c train_config --gpus 0,1 --sweep-file sweeps/experiment.yaml

# Cartesian product: 2x2 = 4 experiments
simplexity-multirun run.py -c train_config --gpus 0,1,2,3 \
    --sweep 'model.n_heads=1,2' \
    --sweep 'model.n_layers=1,2'

# Dry run to preview
simplexity-multirun run.py -c train_config --gpus 0,1 --sweep 'seed=1,2' --dry-run
```

## Files Changed

- `simplexity/cli/__init__.py` (new): CLI module init
- `simplexity/cli/run_parallel.py` (new): Main CLI implementation (~350 lines)
- `pyproject.toml`: Added `[project.scripts]` entry point

## Testing

Tested with dry-run mode and actual experiment runs on multi-GPU machine. Verified:
- GPU isolation works correctly
- CPU mode disables GPU properly
- Sweep file parsing works with OmegaConf
- Staggered starts work as expected
- Error handling and reporting works

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)