### PR TITLE
Improve metric naming for length and readability

### DIFF
--- a/simplexity/activations/visualization/dataframe_builders.py
+++ b/simplexity/activations/visualization/dataframe_builders.py
@@ -26,6 +26,7 @@ from simplexity.activations.visualization_configs import (
     SamplingConfig,
     ScalarSeriesMapping,
 )
+from simplexity.analysis.metric_keys import format_layer_spec
 from simplexity.exceptions import ConfigValidationError
 
 
@@ -155,9 +156,10 @@ def _build_scalar_series_dataframe(
     base_metadata = _scalar_series_metadata(metadata_columns)
     rows: list[dict[str, Any]] = []
     for layer_name in layer_names:
+        formatted_layer = format_layer_spec(layer_name)
         index_values = mapping.index_values or _infer_scalar_series_indices(mapping, scalars, layer_name, analysis_name)
         for index_value in index_values:
-            raw_key = mapping.key_template.format(layer=layer_name, index=index_value)
+            raw_key = mapping.key_template.format(layer=formatted_layer, index=index_value)
             scalar_key = f"{analysis_name}/{raw_key}"
             scalar_value = scalars.get(scalar_key)
             if scalar_value is None:
@@ -183,7 +185,8 @@ def _infer_scalar_series_indices(
     analysis_name: str,
 ) -> list[int]:
     """Infer available indices for scalar series from available scalar keys."""
-    raw_template = mapping.key_template.format(layer=layer_name, index=_SCALAR_INDEX_SENTINEL)
+    formatted_layer = format_layer_spec(layer_name)
+    raw_template = mapping.key_template.format(layer=formatted_layer, index=_SCALAR_INDEX_SENTINEL)
     template = f"{analysis_name}/{raw_template}"
     if _SCALAR_INDEX_SENTINEL not in template:
         raise ConfigValidationError(

--- a/simplexity/activations/visualization/field_resolution.py
+++ b/simplexity/activations/visualization/field_resolution.py
@@ -13,32 +13,71 @@ from simplexity.exceptions import ConfigValidationError
 def _lookup_projection_array(
     projections: Mapping[str, np.ndarray], layer_name: str, key: str | None, concat_layers: bool
 ) -> np.ndarray:
-    """Look up a projection array by key, handling layer naming conventions."""
+    """Look up a projection array by key, handling layer naming conventions.
+
+    Supports keys in the format "{analysis}/{layer_spec}" (e.g., "pca/L0.resid.pre")
+    or "{analysis}/{layer_spec}-{factor_spec}" (e.g., "reg/L0.resid.pre-F0").
+
+    When key contains a factor suffix (e.g., "projected/F0"), looks for the full key
+    "{analysis}/{layer}-{factor}" (e.g., "projected/layer_0-F0").
+    """
     if key is None:
         raise ConfigValidationError("Projection references must supply a `key` value.")
-    suffix = f"_{key}"
+
     for full_key, value in projections.items():
         if concat_layers:
-            if full_key.endswith(suffix) or full_key == key:
+            if full_key.startswith(f"{key}/") or full_key == key:
                 return np.asarray(value)
         else:
-            if not full_key.endswith(suffix):
-                continue
-            candidate_layer = full_key[: -len(suffix)]
-            if candidate_layer == layer_name:
+            if _key_matches_layer(full_key, key, layer_name):
                 return np.asarray(value)
     raise ConfigValidationError(f"Projection '{key}' not available for layer '{layer_name}'.")
 
 
+def _key_matches_layer(full_key: str, key: str, layer_name: str) -> bool:
+    """Check if a full key matches the given key pattern and layer name.
+
+    Handles two formats:
+    - Simple: key="pca" matches full_key="pca/layer_0"
+    - Factor: key="projected/F0" matches full_key="projected/layer_0-F0"
+    """
+    if "/" not in full_key:
+        return False
+
+    # Check if key has a factor suffix (e.g., "projected/F0")
+    if "/" in key:
+        key_parts = key.rsplit("/", 1)
+        analysis_prefix, factor_suffix = key_parts
+        # Look for {analysis}/{layer}-{factor} format
+        expected_key = f"{analysis_prefix}/{layer_name}-{factor_suffix}"
+        return full_key == expected_key
+
+    # Simple key format: key="pca" matches "pca/layer_0"
+    prefix = f"{key}/"
+    if not full_key.startswith(prefix):
+        return False
+    layer_part = full_key[len(prefix) :]
+    candidate_layer = layer_part.split("-")[0]
+    return candidate_layer == layer_name
+
+
 def _lookup_scalar_value(scalars: Mapping[str, float], layer_name: str, key: str, concat_layers: bool) -> float:
-    """Look up a scalar value by key, handling layer naming conventions."""
-    suffix = f"_{key}"
+    """Look up a scalar value by key, handling layer naming conventions.
+
+    Supports keys in the format "{metric}/{layer_spec}" (e.g., "r2/L0.resid.pre")
+    or "{metric}/{layer_spec}-{factor_spec}" (e.g., "r2/L0.resid.pre-F0").
+    """
+    prefix = f"{key}/"
     for full_key, value in scalars.items():
         if concat_layers:
-            if full_key.endswith(suffix) or full_key == key:
+            if full_key.startswith(prefix) or full_key == key:
                 return float(value)
         else:
-            if full_key.endswith(suffix) and full_key[: -len(suffix)] == layer_name:
+            if not full_key.startswith(prefix):
+                continue
+            layer_part = full_key[len(prefix) :]
+            candidate_layer = layer_part.split("-")[0]
+            if candidate_layer == layer_name:
                 return float(value)
     raise ConfigValidationError(f"Scalar '{key}' not available for layer '{layer_name}'.")
 

--- a/simplexity/activations/visualization/field_resolution.py
+++ b/simplexity/activations/visualization/field_resolution.py
@@ -7,12 +7,12 @@ from collections.abc import Mapping
 import numpy as np
 
 from simplexity.activations.visualization_configs import ActivationVisualizationFieldRef
-from simplexity.analysis.metric_keys import format_layer_spec
+from simplexity.analysis.metric_keys import construct_layer_specific_key, format_layer_spec
 from simplexity.exceptions import ConfigValidationError
 
 
 def _lookup_projection_array(
-    projections: Mapping[str, np.ndarray], layer_name: str, key: str | None, concat_layers: bool
+    projections: Mapping[str, np.ndarray], layer_name: str, key: str, concat_layers: bool
 ) -> np.ndarray:
     """Look up a projection array by key, handling layer naming conventions.
 
@@ -20,18 +20,15 @@ def _lookup_projection_array(
     or "{analysis}/{layer_spec}-{factor_spec}" (e.g., "reg/L0.resid.pre-F0").
 
     When key contains a factor suffix (e.g., "projected/F0"), looks for the full key
-    "{analysis}/{layer}-{factor}" (e.g., "projected/layer_0-F0").
+    "{analysis}/{layer_spec}-{factor_spec}" (e.g., "projected/L0.resid.pre-F0").
     """
-    if key is None:
-        raise ConfigValidationError("Projection references must supply a `key` value.")
-
     for full_key, value in projections.items():
         if concat_layers:
-            if full_key.startswith(f"{key}/") or full_key == key:
-                return np.asarray(value)
+            if full_key == key or full_key.startswith(f"{key}/"):
+                return value
         else:
             if _key_matches_layer(full_key, key, layer_name):
-                return np.asarray(value)
+                return value
     raise ConfigValidationError(f"Projection '{key}' not available for layer '{layer_name}'.")
 
 
@@ -51,11 +48,7 @@ def _key_matches_layer(full_key: str, key: str, layer_name: str) -> bool:
 
     # Check if key has a factor suffix (e.g., "projected/F0")
     if "/" in key:
-        key_parts = key.rsplit("/", 1)
-        analysis_prefix, factor_suffix = key_parts
-        # Look for {analysis}/{layer}-{factor} format
-        expected_key = f"{analysis_prefix}/{formatted_layer}-{factor_suffix}"
-        return full_key == expected_key
+        return full_key == construct_layer_specific_key(key, formatted_layer)
 
     # Simple key format: key="pca" matches "pca/L0.resid.pre"
     prefix = f"{key}/"
@@ -177,6 +170,8 @@ def _resolve_field(
         return np.asarray(metadata_columns["weight"])
 
     if ref.source == "projections":
+        if ref.key is None:
+            raise ConfigValidationError("Projection references must supply a `key` value.")
         array = _lookup_projection_array(projections, layer_name, ref.key, analysis_concat_layers)
         if isinstance(ref.component, str):
             raise ConfigValidationError("Component indices should be expanded before resolution")

--- a/simplexity/activations/visualization/field_resolution.py
+++ b/simplexity/activations/visualization/field_resolution.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping
 import numpy as np
 
 from simplexity.activations.visualization_configs import ActivationVisualizationFieldRef
+from simplexity.analysis.metric_keys import format_layer_spec
 from simplexity.exceptions import ConfigValidationError
 
 
@@ -38,27 +39,31 @@ def _key_matches_layer(full_key: str, key: str, layer_name: str) -> bool:
     """Check if a full key matches the given key pattern and layer name.
 
     Handles two formats:
-    - Simple: key="pca" matches full_key="pca/layer_0"
-    - Factor: key="projected/F0" matches full_key="projected/layer_0-F0"
+    - Simple: key="pca" matches full_key="pca/L0.resid.pre"
+    - Factor: key="projected/F0" matches full_key="projected/L0.resid.pre-F0"
+
+    The layer_name is formatted using format_layer_spec before matching.
     """
     if "/" not in full_key:
         return False
+
+    formatted_layer = format_layer_spec(layer_name)
 
     # Check if key has a factor suffix (e.g., "projected/F0")
     if "/" in key:
         key_parts = key.rsplit("/", 1)
         analysis_prefix, factor_suffix = key_parts
         # Look for {analysis}/{layer}-{factor} format
-        expected_key = f"{analysis_prefix}/{layer_name}-{factor_suffix}"
+        expected_key = f"{analysis_prefix}/{formatted_layer}-{factor_suffix}"
         return full_key == expected_key
 
-    # Simple key format: key="pca" matches "pca/layer_0"
+    # Simple key format: key="pca" matches "pca/L0.resid.pre"
     prefix = f"{key}/"
     if not full_key.startswith(prefix):
         return False
     layer_part = full_key[len(prefix) :]
     candidate_layer = layer_part.split("-")[0]
-    return candidate_layer == layer_name
+    return candidate_layer == formatted_layer
 
 
 def _lookup_scalar_value(scalars: Mapping[str, float], layer_name: str, key: str, concat_layers: bool) -> float:
@@ -66,7 +71,10 @@ def _lookup_scalar_value(scalars: Mapping[str, float], layer_name: str, key: str
 
     Supports keys in the format "{metric}/{layer_spec}" (e.g., "r2/L0.resid.pre")
     or "{metric}/{layer_spec}-{factor_spec}" (e.g., "r2/L0.resid.pre-F0").
+
+    The layer_name is formatted using format_layer_spec before matching.
     """
+    formatted_layer = format_layer_spec(layer_name)
     prefix = f"{key}/"
     for full_key, value in scalars.items():
         if concat_layers:
@@ -77,7 +85,7 @@ def _lookup_scalar_value(scalars: Mapping[str, float], layer_name: str, key: str
                 continue
             layer_part = full_key[len(prefix) :]
             candidate_layer = layer_part.split("-")[0]
-            if candidate_layer == layer_name:
+            if candidate_layer == formatted_layer:
                 return float(value)
     raise ConfigValidationError(f"Scalar '{key}' not available for layer '{layer_name}'.")
 

--- a/simplexity/activations/visualization/pattern_expansion.py
+++ b/simplexity/activations/visualization/pattern_expansion.py
@@ -17,6 +17,7 @@ from simplexity.activations.visualization.pattern_utils import (
     validate_single_pattern,
 )
 from simplexity.activations.visualization_configs import ActivationVisualizationFieldRef
+from simplexity.analysis.metric_keys import format_layer_spec
 from simplexity.exceptions import ConfigValidationError
 
 
@@ -149,6 +150,9 @@ def _expand_projection_key_pattern(
         Dict mapping extracted index (as string) to the concrete key suffix.
         E.g., {"0": "factor_0/projected", "1": "factor_1/projected"}
     """
+    # Format layer name to match against projection keys which use formatted names
+    formatted_layer = format_layer_spec(layer_name)
+
     # Build regex from pattern
     if "*" in key_pattern:
         regex_pattern = build_wildcard_regex(key_pattern)
@@ -185,11 +189,11 @@ def _expand_projection_key_pattern(
             analysis_prefix, layer_part = parts
 
             # Check if this key is for the current layer
-            if not layer_part.startswith(layer_name):
+            if not layer_part.startswith(formatted_layer):
                 continue
 
-            # Extract factor suffix if present (e.g., "layer_0-F0" -> "-F0")
-            factor_suffix = layer_part[len(layer_name) :]
+            # Extract factor suffix if present (e.g., "L0.resid.pre-F0" -> "-F0")
+            factor_suffix = layer_part[len(formatted_layer) :]
 
             # Reconstruct a pattern-matchable key suffix
             # Convert "projected/layer_0-F0" to "projected/F0" for pattern matching

--- a/simplexity/activations/visualization/pattern_expansion.py
+++ b/simplexity/activations/visualization/pattern_expansion.py
@@ -170,16 +170,33 @@ def _expand_projection_key_pattern(
     # Match against available projection keys
     result: dict[str, str] = {}
     for full_key in projections:
-        # Extract the key suffix (part after layer name)
+        # Extract the key suffix for pattern matching
         if analysis_concat_layers:
-            # Keys are like "factor_0/projected" directly
+            # Keys are like "analysis/Lcat" or "analysis/Lcat-F0" directly
             key_suffix = full_key
         else:
-            # Keys are like "layer_name_factor_0/projected"
-            prefix = f"{layer_name}_"
-            if not full_key.startswith(prefix):
+            # New format: keys are like "analysis/layer_name" or "analysis/layer_name-F0"
+            # Extract the analysis prefix and factor suffix for matching
+            if "/" not in full_key:
                 continue
-            key_suffix = full_key[len(prefix) :]
+            parts = full_key.rsplit("/", 1)
+            if len(parts) != 2:
+                continue
+            analysis_prefix, layer_part = parts
+
+            # Check if this key is for the current layer
+            if not layer_part.startswith(layer_name):
+                continue
+
+            # Extract factor suffix if present (e.g., "layer_0-F0" -> "-F0")
+            factor_suffix = layer_part[len(layer_name) :]
+
+            # Reconstruct a pattern-matchable key suffix
+            # Convert "projected/layer_0-F0" to "projected/F0" for pattern matching
+            if factor_suffix.startswith("-"):
+                key_suffix = f"{analysis_prefix}/{factor_suffix[1:]}"
+            else:
+                key_suffix = analysis_prefix
 
         match = regex_pattern.match(key_suffix)
         if match:
@@ -419,14 +436,14 @@ def _expand_scalar_pattern_keys(
 ) -> list[str]:
     """Expand wildcard/range pattern against available scalar keys."""
     keys = list(available_keys)
-    has_prefixed_keys = any("/" in key for key in keys)
     prefix = f"{analysis_name}/"
+    keys_have_prefix = any(key.startswith(prefix) for key in keys)
 
     normalized_pattern = pattern
-    if "/" not in normalized_pattern and has_prefixed_keys:
-        normalized_pattern = f"{analysis_name}/{normalized_pattern}"
-    elif "/" in normalized_pattern and not has_prefixed_keys and normalized_pattern.startswith(prefix):
-        normalized_pattern = normalized_pattern[len(prefix) :]
+    if keys_have_prefix and not pattern.startswith(prefix):
+        normalized_pattern = f"{prefix}{pattern}"
+    elif not keys_have_prefix and pattern.startswith(prefix):
+        normalized_pattern = pattern[len(prefix) :]
 
     pattern_variants = _expand_scalar_pattern_ranges(normalized_pattern)
     matched: list[str] = []

--- a/simplexity/activations/visualization/pattern_expansion.py
+++ b/simplexity/activations/visualization/pattern_expansion.py
@@ -120,7 +120,7 @@ def _get_component_count(
             raise ConfigValidationError(f"Projection must be 1D or 2D, got {np_array.ndim}D")
         return np_array.shape[1]
 
-    elif ref.source == "belief_states":
+    if ref.source == "belief_states":
         if belief_states is None:
             raise ConfigValidationError("Belief states not available")
         np_array = np.asarray(belief_states)
@@ -128,8 +128,7 @@ def _get_component_count(
             raise ConfigValidationError(f"Belief states must be 2D, got {np_array.ndim}D")
         return np_array.shape[1]
 
-    else:
-        raise ConfigValidationError(f"Component expansion not supported for source: {ref.source}")
+    raise ConfigValidationError(f"Component expansion not supported for source: {ref.source}")
 
 
 def _expand_projection_key_pattern(
@@ -222,7 +221,6 @@ def _expand_projection_key_mapping(
     ref: ActivationVisualizationFieldRef,
     layer_name: str,
     projections: Mapping[str, np.ndarray],
-    belief_states: np.ndarray | None,
     analysis_concat_layers: bool,
 ) -> dict[str, ActivationVisualizationFieldRef]:
     """Expand projection key patterns, optionally combined with component patterns.
@@ -409,7 +407,6 @@ def _expand_belief_factor_mapping(
 def _expand_scalar_keys(
     field_pattern: str,
     key_pattern: str | None,
-    layer_name: str,
     scalars: Mapping[str, float],
 ) -> dict[str, str]:
     """Expand scalar field patterns by matching available scalar keys.
@@ -526,9 +523,7 @@ def _expand_field_mapping(
                 f"Field name '{field_name}' has too many patterns (max 2 for key+component expansion)"
             )
 
-        return _expand_projection_key_mapping(
-            field_name, ref, layer_name, projections, belief_states, analysis_concat_layers
-        )
+        return _expand_projection_key_mapping(field_name, ref, layer_name, projections, analysis_concat_layers)
 
     # Check for belief state factor patterns
     if ref.source == "belief_states" and ref.factor is not None and isinstance(ref.factor, str):
@@ -560,7 +555,7 @@ def _expand_field_mapping(
         if not field_has_pattern:
             return {field_name: ref}
 
-        scalar_expansions = _expand_scalar_keys(field_name, ref.key, layer_name, scalars)
+        scalar_expansions = _expand_scalar_keys(field_name, ref.key, scalars)
         return {
             field: ActivationVisualizationFieldRef(source="scalars", key=key, component=None, reducer=None)
             for field, key in scalar_expansions.items()

--- a/simplexity/analysis/layerwise_analysis.py
+++ b/simplexity/analysis/layerwise_analysis.py
@@ -196,11 +196,12 @@ class LayerwiseAnalysis:
                 belief_states,
                 **self._analysis_kwargs,
             )
+            formatted_layer_name = format_layer_spec(layer_name)
             for key, value in layer_scalars.items():
-                constructed_key = construct_layer_specific_key(key, layer_name)
+                constructed_key = construct_layer_specific_key(key, formatted_layer_name)
                 scalars[constructed_key] = value
             for key, value in layer_projections.items():
-                constructed_key = construct_layer_specific_key(key, layer_name)
+                constructed_key = construct_layer_specific_key(key, formatted_layer_name)
                 projections[constructed_key] = value
         return scalars, projections
 

--- a/simplexity/analysis/layerwise_analysis.py
+++ b/simplexity/analysis/layerwise_analysis.py
@@ -22,7 +22,7 @@ from simplexity.analysis.pca import (
     layer_pca_analysis,
 )
 from simplexity.logger import SIMPLEXITY_LOGGER
-from simplexity.analysis.metric_keys import construct_layer_specific_key
+from simplexity.analysis.metric_keys import construct_layer_specific_key, format_layer_spec
 
 AnalysisFn = Callable[..., tuple[Mapping[str, float], Mapping[str, jax.Array]]]
 

--- a/simplexity/analysis/layerwise_analysis.py
+++ b/simplexity/analysis/layerwise_analysis.py
@@ -22,6 +22,7 @@ from simplexity.analysis.pca import (
     layer_pca_analysis,
 )
 from simplexity.logger import SIMPLEXITY_LOGGER
+from simplexity.analysis.metric_keys import construct_layer_specific_key
 
 AnalysisFn = Callable[..., tuple[Mapping[str, float], Mapping[str, jax.Array]]]
 
@@ -196,9 +197,11 @@ class LayerwiseAnalysis:
                 **self._analysis_kwargs,
             )
             for key, value in layer_scalars.items():
-                scalars[f"{layer_name}_{key}"] = value
+                constructed_key = construct_layer_specific_key(key, layer_name)
+                scalars[constructed_key] = value
             for key, value in layer_projections.items():
-                projections[f"{layer_name}_{key}"] = value
+                constructed_key = construct_layer_specific_key(key, layer_name)
+                projections[constructed_key] = value
         return scalars, projections
 
 

--- a/simplexity/analysis/layerwise_analysis.py
+++ b/simplexity/analysis/layerwise_analysis.py
@@ -17,12 +17,12 @@ from typing import Any
 import jax
 
 from simplexity.analysis.linear_regression import layer_linear_regression
+from simplexity.analysis.metric_keys import construct_layer_specific_key, format_layer_spec
 from simplexity.analysis.pca import (
     DEFAULT_VARIANCE_THRESHOLDS,
     layer_pca_analysis,
 )
 from simplexity.logger import SIMPLEXITY_LOGGER
-from simplexity.analysis.metric_keys import construct_layer_specific_key, format_layer_spec
 
 AnalysisFn = Callable[..., tuple[Mapping[str, float], Mapping[str, jax.Array]]]
 

--- a/simplexity/analysis/linear_regression.py
+++ b/simplexity/analysis/linear_regression.py
@@ -389,12 +389,12 @@ def _compute_subspace_orthogonality(
     effective_rank = jnp.exp(entropy)
 
     scalars = {
-        "subspace_overlap": float(subspace_overlap_score),
-        "max_singular_value": float(jnp.max(singular_values)),
-        "min_singular_value": float(jnp.min(singular_values)),
-        "participation_ratio": float(participation_ratio),
+        "overlap": float(subspace_overlap_score),
+        "sv_max": float(jnp.max(singular_values)),
+        "sv_min": float(jnp.min(singular_values)),
+        "p_ratio": float(participation_ratio),
         "entropy": float(entropy),
-        "effective_rank": float(effective_rank),
+        "eff_rank": float(effective_rank),
     }
 
     arrays = {

--- a/simplexity/analysis/linear_regression.py
+++ b/simplexity/analysis/linear_regression.py
@@ -227,6 +227,16 @@ def _merge_results_with_prefix(
     scalars.update({f"{prefix}/{key}": value for key, value in results_scalars.items()})
     arrays.update({f"{prefix}/{key}": value for key, value in results_arrays.items()})
 
+def _merge_results_with_suffix(
+    scalars: dict[str, float],
+    arrays: dict[str, jax.Array],
+    results: tuple[Mapping[str, float], Mapping[str, jax.Array]],
+    suffix: str,
+) -> None:
+    results_scalars, results_arrays = results
+    scalars.update({f"{key}/{suffix}": value for key, value in results_scalars.items()})
+    arrays.update({f"{key}/{suffix}": value for key, value in results_arrays.items()})
+
 
 def _split_concat_results(
     layer_activations: jax.Array,
@@ -426,8 +436,8 @@ def _compute_all_pairwise_orthogonality(
     for i, j in factor_pairs:
         basis_pair = [basis_list[i], basis_list[j]]
         orthogonality_scalars, orthogonality_arrays = _compute_subspace_orthogonality(basis_pair)
-        scalars.update({f"orthogonality_{i}_{j}/{key}": value for key, value in orthogonality_scalars.items()})
-        arrays.update({f"orthogonality_{i}_{j}/{key}": value for key, value in orthogonality_arrays.items()})
+        scalars.update({f"{i},{j}/{key}": value for key, value in orthogonality_scalars.items()})
+        arrays.update({f"{i},{j}/{key}": value for key, value in orthogonality_arrays.items()})
     return scalars, arrays
 
 
@@ -453,7 +463,7 @@ def _handle_factored_regression(
     if concat_belief_states:
         belief_states_concat = jnp.concatenate(belief_states, axis=-1)
         concat_results = regression_fn(layer_activations, belief_states_concat, weights, **kwargs)
-        _merge_results_with_prefix(scalars, arrays, concat_results, "concat")
+        _merge_results_with_suffix(scalars, arrays, concat_results, "Fcat")
 
         # Split the concatenated parameters and projections into the individual factors
         factor_results = _split_concat_results(
@@ -467,15 +477,20 @@ def _handle_factored_regression(
         factor_results = _process_individual_factors(layer_activations, belief_states, weights, use_svd, **kwargs)
 
     for factor_idx, factor_result in enumerate(factor_results):
-        _merge_results_with_prefix(scalars, arrays, factor_result, f"factor_{factor_idx}")
+        _merge_results_with_suffix(scalars, arrays, factor_result, f"F{factor_idx}")
 
     if compute_subspace_orthogonality:
         # Extract coefficients (excludes intercept) for orthogonality computation
         coeffs_list = [factor_arrays["coeffs"] for _, factor_arrays in factor_results]
-        orthogonality_scalars, orthogonality_singular_values = _compute_all_pairwise_orthogonality(coeffs_list)
-        scalars.update(orthogonality_scalars)
-        arrays.update(orthogonality_singular_values)
-
+        orthogonality_scalars, orthogonality_arrays = _compute_all_pairwise_orthogonality(coeffs_list)
+        for key, value in orthogonality_scalars.items():
+            factors, metric = key.split("/")
+            new_key = f"orth/{metric}/F{factors}"
+            scalars.update({new_key: value})
+        for key, value in orthogonality_arrays.items():
+            factors, metric = key.split("/")
+            new_key = f"orth/{metric}/F{factors}"
+            arrays.update({new_key: value})
     return scalars, arrays
 
 

--- a/simplexity/analysis/linear_regression.py
+++ b/simplexity/analysis/linear_regression.py
@@ -227,6 +227,7 @@ def _merge_results_with_prefix(
     scalars.update({f"{prefix}/{key}": value for key, value in results_scalars.items()})
     arrays.update({f"{prefix}/{key}": value for key, value in results_arrays.items()})
 
+
 def _merge_results_with_suffix(
     scalars: dict[str, float],
     arrays: dict[str, jax.Array],

--- a/simplexity/analysis/metric_keys.py
+++ b/simplexity/analysis/metric_keys.py
@@ -1,0 +1,60 @@
+"""Utility functions for constructing layer-specific analysis keys for scalar and array metrics."""
+
+from __future__ import annotations
+
+import re
+
+def construct_layer_specific_key(key: str, layer_name: str) -> str:
+    """Construct a layer-specific namespaced metric key."""
+    split_key = key.split("/")
+    last_part = split_key[-1]
+    if last_part.startswith("F") and len(split_key) > 1: # If the key is a factor-specific key, prepend the layer name
+        new_last_part = f"{layer_name}-{last_part}"
+        new_key = "/".join(split_key[:-1] + [new_last_part])
+    else:
+        new_last_part = f"{layer_name}"
+        new_key = "/".join(split_key + [new_last_part])
+    return new_key
+
+def format_layer_spec(layer_name: str) -> str:
+    """Format layer name into compact layer specification.
+    
+    Converts verbose layer names to compact specs:
+    - Block layers: "blocks.N.hook_X_Y" → "LN.X.Y"
+    - Special layers: "embed", "pos_embed", "ln_final" → unchanged
+    - Concatenated: "concatenated" → "Lcat"
+    
+    Args:
+        layer_name: Original layer name from activations dict
+        
+    Returns:
+        Formatted layer spec
+        
+    Examples:
+        >>> format_layer_spec("blocks.2.hook_resid_post")
+        "L2.resid.post"
+        >>> format_layer_spec("blocks.0.hook_resid_pre")
+        "L0.resid.pre"
+        >>> format_layer_spec("blocks.10.hook_mlp_out")
+        "L10.mlp.out"
+        >>> format_layer_spec("embed")
+        "embed"
+        >>> format_layer_spec("concatenated")
+        "Lcat"
+    """
+    
+    if layer_name == "concatenated":
+        return "Lcat"
+    
+    if not layer_name.startswith("blocks."):
+        return layer_name
+
+    block_pattern = r"^blocks\.(\d+)\.hook_(.+)$"
+    match = re.match(block_pattern, layer_name)
+    if match:
+        block_num = match.group(1)
+        hook_name = match.group(2)
+        simplified_hook_name = hook_name.replace("_", ".")
+        return f"L{block_num}.{simplified_hook_name}"
+    
+    return layer_name

--- a/simplexity/analysis/metric_keys.py
+++ b/simplexity/analysis/metric_keys.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import re
 
+
 def construct_layer_specific_key(key: str, layer_name: str) -> str:
     """Construct a layer-specific namespaced metric key."""
     split_key = key.split("/")
     last_part = split_key[-1]
-    if last_part.startswith("F") and len(split_key) > 1: # If the key is a factor-specific key, prepend the layer name
+    if last_part.startswith("F") and len(split_key) > 1:  # If the key is a factor-specific key, prepend the layer name
         new_last_part = f"{layer_name}-{last_part}"
         new_key = "/".join(split_key[:-1] + [new_last_part])
     else:
@@ -16,20 +17,21 @@ def construct_layer_specific_key(key: str, layer_name: str) -> str:
         new_key = "/".join(split_key + [new_last_part])
     return new_key
 
+
 def format_layer_spec(layer_name: str) -> str:
     """Format layer name into compact layer specification.
-    
+
     Converts verbose layer names to compact specs:
     - Block layers: "blocks.N.hook_X_Y" → "LN.X.Y"
     - Special layers: "embed", "pos_embed", "ln_final" → unchanged
     - Concatenated: "concatenated" → "Lcat"
-    
+
     Args:
         layer_name: Original layer name from activations dict
-        
+
     Returns:
         Formatted layer spec
-        
+
     Examples:
         >>> format_layer_spec("blocks.2.hook_resid_post")
         "L2.resid.post"
@@ -42,10 +44,9 @@ def format_layer_spec(layer_name: str) -> str:
         >>> format_layer_spec("concatenated")
         "Lcat"
     """
-    
     if layer_name == "concatenated":
         return "Lcat"
-    
+
     if not layer_name.startswith("blocks."):
         return layer_name
 
@@ -56,5 +57,5 @@ def format_layer_spec(layer_name: str) -> str:
         hook_name = match.group(2)
         simplified_hook_name = hook_name.replace("_", ".")
         return f"L{block_num}.{simplified_hook_name}"
-    
+
     return layer_name

--- a/simplexity/analysis/metric_keys.py
+++ b/simplexity/analysis/metric_keys.py
@@ -7,15 +7,16 @@ import re
 
 def construct_layer_specific_key(key: str, layer_name: str) -> str:
     """Construct a layer-specific namespaced metric key."""
-    split_key = key.split("/")
-    last_part = split_key[-1]
-    if last_part.startswith("F") and len(split_key) > 1:  # If the key is a factor-specific key, prepend the layer name
-        new_last_part = f"{layer_name}-{last_part}"
-        new_key = "/".join(split_key[:-1] + [new_last_part])
-    else:
-        new_last_part = f"{layer_name}"
-        new_key = "/".join(split_key + [new_last_part])
-    return new_key
+    if "/" not in key:
+        return f"{key}/{layer_name}"
+
+    # If the key is factor-specific (e.g. "rmse/F0")
+    # prepend the layer name to the factor (e.g. "rmse/L0.resid.post-F0")
+    analysis, factor = key.rsplit("/", 1)
+    if factor.startswith("F"):
+        return f"{analysis}/{layer_name}-{factor}"
+
+    return f"{key}/{layer_name}"
 
 
 def format_layer_spec(layer_name: str) -> str:
@@ -50,11 +51,11 @@ def format_layer_spec(layer_name: str) -> str:
     if not layer_name.startswith("blocks."):
         return layer_name
 
-    block_pattern = r"^blocks\.(\d+)\.hook_(.+)$"
+    block_pattern = r"^blocks\.(?P<block_num>\d+)\.hook_(?P<hook_name>.+)$"
     match = re.match(block_pattern, layer_name)
     if match:
-        block_num = match.group(1)
-        hook_name = match.group(2)
+        block_num = match.group("block_num")
+        hook_name = match.group("hook_name")
         simplified_hook_name = hook_name.replace("_", ".")
         return f"L{block_num}.{simplified_hook_name}"
 

--- a/simplexity/analysis/pca.py
+++ b/simplexity/analysis/pca.py
@@ -117,7 +117,7 @@ def layer_pca_analysis(
     scalars: dict[str, float] = {}
     for idx, value in enumerate(cumulative_variance, start=1):
         scalars[f"cumvar_{idx}"] = float(value)
-    scalars["variance_explained"] = float(cumulative_variance[-1])
+    scalars["var_exp"] = float(cumulative_variance[-1])
 
     threshold_counts = variance_threshold_counts(
         result["all_explained_variance_ratio"],
@@ -125,7 +125,7 @@ def layer_pca_analysis(
     )
     for threshold, count in threshold_counts.items():
         percentage = int(threshold * 100)
-        scalars[f"n_components_{percentage}pct"] = float(count)
+        scalars[f"nc_{percentage}"] = float(count)
 
     projections = {"pca": result["X_proj"]}
     return scalars, projections

--- a/tests/activations/test_activation_analysis.py
+++ b/tests/activations/test_activation_analysis.py
@@ -402,8 +402,8 @@ class TestPcaAnalysis:
         assert "cumvar_3/layer_0" in scalars
         assert scalars["cumvar_1/layer_0"] <= scalars["cumvar_2/layer_0"]
         assert scalars["cumvar_2/layer_0"] <= scalars["cumvar_3/layer_0"]
-        assert "n_components_80pct/layer_0" in scalars
-        assert "n_components_90pct/layer_0" in scalars
+        assert "nc_80/layer_0" in scalars
+        assert "nc_90/layer_0" in scalars
         assert "cumvar_1/layer_1" in scalars
 
         assert "pca/layer_0" in projections
@@ -495,7 +495,7 @@ class TestActivationTracker:
         )
 
         assert "regression/r2/layer_0" in scalars
-        assert "pca/variance_explained/layer_0" in scalars
+        assert "pca/var_exp/layer_0" in scalars
 
         assert "regression/projected/layer_0" in projections
         assert "pca/pca/layer_0" in projections
@@ -547,7 +547,7 @@ class TestActivationTracker:
         )
 
         assert "regression/r2/layer_0" in scalars
-        assert "pca/variance_explained/layer_0" in scalars
+        assert "pca/var_exp/layer_0" in scalars
         assert visualizations == {}
 
     def test_concatenated_layers(self, synthetic_data):
@@ -574,7 +574,7 @@ class TestActivationTracker:
         )
 
         assert "regression/r2/Lcat" in scalars
-        assert "pca/variance_explained/Lcat" in scalars
+        assert "pca/var_exp/Lcat" in scalars
 
         assert "regression/projected/Lcat" in projections
         assert "pca/pca/Lcat" in projections
@@ -630,8 +630,8 @@ class TestActivationTracker:
             activations=synthetic_data["activations"],
         )
 
-        assert "pca_all_tokens/variance_explained/layer_0" in scalars
-        assert "pca_last_token/variance_explained/layer_0" in scalars
+        assert "pca_all_tokens/var_exp/layer_0" in scalars
+        assert "pca_last_token/var_exp/layer_0" in scalars
         assert "regression_concat/r2/Lcat" in scalars
 
         assert "pca_all_tokens/pca/layer_0" in projections
@@ -990,7 +990,7 @@ class TestTupleBeliefStates:
         assert "regression/r2/layer_0-F1" in scalars
 
         # PCA should still work (doesn't use belief states)
-        assert "pca/variance_explained/layer_0" in scalars
+        assert "pca/var_exp/layer_0" in scalars
 
         # Projections should be present
         assert "regression/projected/layer_0-F0" in projections

--- a/tests/activations/test_activation_analysis.py
+++ b/tests/activations/test_activation_analysis.py
@@ -237,19 +237,19 @@ class TestLinearRegressionAnalysis:
             weights=prepared.weights,
         )
 
-        assert "layer_0_r2" in scalars
-        assert "layer_0_rmse" in scalars
-        assert "layer_0_mae" in scalars
-        assert "layer_0_dist" in scalars
-        assert "layer_1_r2" in scalars
+        assert "r2/layer_0" in scalars
+        assert "rmse/layer_0" in scalars
+        assert "mae/layer_0" in scalars
+        assert "dist/layer_0" in scalars
+        assert "r2/layer_1" in scalars
 
-        assert "layer_0_projected" in projections
-        assert "layer_1_projected" in projections
+        assert "projected/layer_0" in projections
+        assert "projected/layer_1" in projections
 
         assert prepared.belief_states is not None
         assert isinstance(prepared.belief_states, jax.Array)
-        assert projections["layer_0_projected"].shape == prepared.belief_states.shape
-        assert projections["layer_1_projected"].shape == prepared.belief_states.shape
+        assert projections["projected/layer_0"].shape == prepared.belief_states.shape
+        assert projections["projected/layer_1"].shape == prepared.belief_states.shape
 
     def test_requires_belief_states(self, synthetic_data):
         """Test that analysis raises error without belief_states."""
@@ -298,8 +298,8 @@ class TestLinearRegressionAnalysis:
             weights=prepared.weights,
         )
 
-        assert "layer_0_r2" in scalars
-        assert "layer_0_projected" in projections
+        assert "r2/layer_0" in scalars
+        assert "projected/layer_0" in projections
 
 
 class TestLinearRegressionSVDAnalysis:
@@ -327,24 +327,24 @@ class TestLinearRegressionSVDAnalysis:
             weights=prepared.weights,
         )
 
-        assert "layer_0_r2" in scalars
-        assert "layer_0_rmse" in scalars
-        assert "layer_0_mae" in scalars
-        assert "layer_0_dist" in scalars
-        assert "layer_0_best_rcond" in scalars
-        assert "layer_1_r2" in scalars
-        assert "layer_1_best_rcond" in scalars
+        assert "r2/layer_0" in scalars
+        assert "rmse/layer_0" in scalars
+        assert "mae/layer_0" in scalars
+        assert "dist/layer_0" in scalars
+        assert "best_rcond/layer_0" in scalars
+        assert "r2/layer_1" in scalars
+        assert "best_rcond/layer_1" in scalars
 
-        assert "layer_0_projected" in projections
-        assert "layer_1_projected" in projections
+        assert "projected/layer_0" in projections
+        assert "projected/layer_1" in projections
 
         assert prepared.belief_states is not None
         assert isinstance(prepared.belief_states, jax.Array)
-        assert projections["layer_0_projected"].shape == prepared.belief_states.shape
-        assert projections["layer_1_projected"].shape == prepared.belief_states.shape
+        assert projections["projected/layer_0"].shape == prepared.belief_states.shape
+        assert projections["projected/layer_1"].shape == prepared.belief_states.shape
 
         # Check that best_rcond is one of the provided values
-        assert scalars["layer_0_best_rcond"] in [1e-15, 1e-10, 1e-8]
+        assert scalars["best_rcond/layer_0"] in [1e-15, 1e-10, 1e-8]
 
     def test_requires_belief_states(self, synthetic_data):
         """Test that SVD analysis raises error without belief_states."""
@@ -397,21 +397,21 @@ class TestPcaAnalysis:
             weights=prepared.weights,
         )
 
-        assert "layer_0_cumvar_1" in scalars
-        assert "layer_0_cumvar_2" in scalars
-        assert "layer_0_cumvar_3" in scalars
-        assert scalars["layer_0_cumvar_1"] <= scalars["layer_0_cumvar_2"]
-        assert scalars["layer_0_cumvar_2"] <= scalars["layer_0_cumvar_3"]
-        assert "layer_0_n_components_80pct" in scalars
-        assert "layer_0_n_components_90pct" in scalars
-        assert "layer_1_cumvar_1" in scalars
+        assert "cumvar_1/layer_0" in scalars
+        assert "cumvar_2/layer_0" in scalars
+        assert "cumvar_3/layer_0" in scalars
+        assert scalars["cumvar_1/layer_0"] <= scalars["cumvar_2/layer_0"]
+        assert scalars["cumvar_2/layer_0"] <= scalars["cumvar_3/layer_0"]
+        assert "n_components_80pct/layer_0" in scalars
+        assert "n_components_90pct/layer_0" in scalars
+        assert "cumvar_1/layer_1" in scalars
 
-        assert "layer_0_pca" in projections
-        assert "layer_1_pca" in projections
+        assert "pca/layer_0" in projections
+        assert "pca/layer_1" in projections
 
         batch_size = prepared.activations["layer_0"].shape[0]
-        assert projections["layer_0_pca"].shape == (batch_size, 3)
-        assert projections["layer_1_pca"].shape == (batch_size, 3)
+        assert projections["pca/layer_0"].shape == (batch_size, 3)
+        assert projections["pca/layer_1"].shape == (batch_size, 3)
 
     def test_pca_without_belief_states(self, synthetic_data):
         """Test PCA works without belief_states."""
@@ -437,9 +437,9 @@ class TestPcaAnalysis:
             weights=prepared.weights,
         )
 
-        assert "layer_0_cumvar_1" in scalars
-        assert "layer_0_cumvar_2" in scalars
-        assert "layer_0_pca" in projections
+        assert "cumvar_1/layer_0" in scalars
+        assert "cumvar_2/layer_0" in scalars
+        assert "pca/layer_0" in projections
 
     def test_pca_all_components(self, synthetic_data):
         """Test PCA with n_components=None computes all components."""
@@ -465,7 +465,7 @@ class TestPcaAnalysis:
 
         batch_size = prepared.activations["layer_0"].shape[0]
         d_layer0 = synthetic_data["d_layer0"]
-        assert projections["layer_0_pca"].shape == (batch_size, min(batch_size, d_layer0))
+        assert projections["pca/layer_0"].shape == (batch_size, min(batch_size, d_layer0))
 
 
 class TestActivationTracker:
@@ -494,11 +494,11 @@ class TestActivationTracker:
             activations=synthetic_data["activations"],
         )
 
-        assert "regression/layer_0_r2" in scalars
-        assert "pca/layer_0_variance_explained" in scalars
+        assert "regression/r2/layer_0" in scalars
+        assert "pca/variance_explained/layer_0" in scalars
 
-        assert "regression/layer_0_projected" in projections
-        assert "pca/layer_0_pca" in projections
+        assert "regression/projected/layer_0" in projections
+        assert "pca/pca/layer_0" in projections
         assert visualizations == {}
 
     def test_all_tokens_mode(self, synthetic_data):
@@ -519,8 +519,8 @@ class TestActivationTracker:
             activations=synthetic_data["activations"],
         )
 
-        assert "regression/layer_0_r2" in scalars
-        assert "regression/layer_0_projected" in projections
+        assert "regression/r2/layer_0" in scalars
+        assert "regression/projected/layer_0" in projections
         assert visualizations == {}
 
     def test_mixed_requirements(self, synthetic_data):
@@ -546,8 +546,8 @@ class TestActivationTracker:
             activations=synthetic_data["activations"],
         )
 
-        assert "regression/layer_0_r2" in scalars
-        assert "pca/layer_0_variance_explained" in scalars
+        assert "regression/r2/layer_0" in scalars
+        assert "pca/variance_explained/layer_0" in scalars
         assert visualizations == {}
 
     def test_concatenated_layers(self, synthetic_data):
@@ -573,11 +573,11 @@ class TestActivationTracker:
             activations=synthetic_data["activations"],
         )
 
-        assert "regression/concatenated_r2" in scalars
-        assert "pca/concatenated_variance_explained" in scalars
+        assert "regression/r2/Lcat" in scalars
+        assert "pca/variance_explained/Lcat" in scalars
 
-        assert "regression/concatenated_projected" in projections
-        assert "pca/concatenated_pca" in projections
+        assert "regression/projected/Lcat" in projections
+        assert "pca/pca/Lcat" in projections
         assert visualizations == {}
 
     def test_uniform_weights(self, synthetic_data):
@@ -599,7 +599,7 @@ class TestActivationTracker:
             activations=synthetic_data["activations"],
         )
 
-        assert "regression/layer_0_r2" in scalars
+        assert "regression/r2/layer_0" in scalars
         assert visualizations == {}
 
     def test_multiple_configs_efficiency(self, synthetic_data):
@@ -630,13 +630,13 @@ class TestActivationTracker:
             activations=synthetic_data["activations"],
         )
 
-        assert "pca_all_tokens/layer_0_variance_explained" in scalars
-        assert "pca_last_token/layer_0_variance_explained" in scalars
-        assert "regression_concat/concatenated_r2" in scalars
+        assert "pca_all_tokens/variance_explained/layer_0" in scalars
+        assert "pca_last_token/variance_explained/layer_0" in scalars
+        assert "regression_concat/r2/Lcat" in scalars
 
-        assert "pca_all_tokens/layer_0_pca" in projections
-        assert "pca_last_token/layer_0_pca" in projections
-        assert "regression_concat/concatenated_projected" in projections
+        assert "pca_all_tokens/pca/layer_0" in projections
+        assert "pca_last_token/pca/layer_0" in projections
+        assert "regression_concat/projected/Lcat" in projections
         assert visualizations == {}
 
     def test_tracker_accepts_torch_inputs(self, synthetic_data):
@@ -670,8 +670,8 @@ class TestActivationTracker:
             activations=torch_activations,
         )
 
-        assert "regression/layer_0_r2" in scalars
-        assert "pca/layer_0_pca" in projections
+        assert "regression/r2/layer_0" in scalars
+        assert "pca/pca/layer_0" in projections
         assert visualizations == {}
 
     def test_tracker_builds_visualizations(self, synthetic_data, monkeypatch):
@@ -907,28 +907,28 @@ class TestTupleBeliefStates:
 
         # Should have separate metrics for each factor
         # Format is: layer_name_factor_idx/metric_name
-        assert "layer_0_factor_0/r2" in scalars
-        assert "layer_0_factor_1/r2" in scalars
-        assert "layer_0_factor_0/rmse" in scalars
-        assert "layer_0_factor_1/rmse" in scalars
-        assert "layer_0_factor_0/mae" in scalars
-        assert "layer_0_factor_1/mae" in scalars
-        assert "layer_0_factor_0/dist" in scalars
-        assert "layer_0_factor_1/dist" in scalars
+        assert "r2/layer_0-F0" in scalars
+        assert "r2/layer_0-F1" in scalars
+        assert "rmse/layer_0-F0" in scalars
+        assert "rmse/layer_0-F1" in scalars
+        assert "mae/layer_0-F0" in scalars
+        assert "mae/layer_0-F1" in scalars
+        assert "dist/layer_0-F0" in scalars
+        assert "dist/layer_0-F1" in scalars
 
-        assert "layer_1_factor_0/r2" in scalars
-        assert "layer_1_factor_1/r2" in scalars
+        assert "r2/layer_1-F0" in scalars
+        assert "r2/layer_1-F1" in scalars
 
         # Should have separate projections for each factor
-        assert "layer_0_factor_0/projected" in projections
-        assert "layer_0_factor_1/projected" in projections
-        assert "layer_1_factor_0/projected" in projections
-        assert "layer_1_factor_1/projected" in projections
+        assert "projected/layer_0-F0" in projections
+        assert "projected/layer_0-F1" in projections
+        assert "projected/layer_1-F0" in projections
+        assert "projected/layer_1-F1" in projections
 
         # Check projection shapes
         batch_size = factored_belief_data["batch_size"]
-        assert projections["layer_0_factor_0/projected"].shape == (batch_size, factored_belief_data["factor_0_dim"])
-        assert projections["layer_0_factor_1/projected"].shape == (batch_size, factored_belief_data["factor_1_dim"])
+        assert projections["projected/layer_0-F0"].shape == (batch_size, factored_belief_data["factor_0_dim"])
+        assert projections["projected/layer_0-F1"].shape == (batch_size, factored_belief_data["factor_1_dim"])
 
     def test_linear_regression_svd_with_multiple_factors(self, factored_belief_data):
         """LinearRegressionSVDAnalysis with multi-factor tuple should regress to each factor separately."""
@@ -953,14 +953,14 @@ class TestTupleBeliefStates:
         )
 
         # Should have separate metrics for each factor including best_rcond
-        assert "layer_0_factor_0/r2" in scalars
-        assert "layer_0_factor_1/r2" in scalars
-        assert "layer_0_factor_0/best_rcond" in scalars
-        assert "layer_0_factor_1/best_rcond" in scalars
+        assert "r2/layer_0-F0" in scalars
+        assert "r2/layer_0-F1" in scalars
+        assert "best_rcond/layer_0-F0" in scalars
+        assert "best_rcond/layer_0-F1" in scalars
 
         # Should have separate projections for each factor
-        assert "layer_0_factor_0/projected" in projections
-        assert "layer_0_factor_1/projected" in projections
+        assert "projected/layer_0-F0" in projections
+        assert "projected/layer_0-F1" in projections
 
     def test_tracker_with_factored_beliefs(self, factored_belief_data):
         """ActivationTracker should work with tuple belief states."""
@@ -986,16 +986,16 @@ class TestTupleBeliefStates:
         )
 
         # Regression should have per-factor metrics
-        assert "regression/layer_0_factor_0/r2" in scalars
-        assert "regression/layer_0_factor_1/r2" in scalars
+        assert "regression/r2/layer_0-F0" in scalars
+        assert "regression/r2/layer_0-F1" in scalars
 
         # PCA should still work (doesn't use belief states)
-        assert "pca/layer_0_variance_explained" in scalars
+        assert "pca/variance_explained/layer_0" in scalars
 
         # Projections should be present
-        assert "regression/layer_0_factor_0/projected" in projections
-        assert "regression/layer_0_factor_1/projected" in projections
-        assert "pca/layer_0_pca" in projections
+        assert "regression/projected/layer_0-F0" in projections
+        assert "regression/projected/layer_0-F1" in projections
+        assert "pca/pca/layer_0" in projections
 
     def test_single_factor_tuple(self, synthetic_data):
         """Test with a single-factor tuple (edge case)."""
@@ -1043,13 +1043,13 @@ class TestTupleBeliefStates:
         )
 
         # Should have simple keys without "factor_" prefix
-        assert "layer_0_r2" in scalars
-        assert "layer_0_rmse" in scalars
-        assert "layer_0_projected" in projections
+        assert "r2/layer_0" in scalars
+        assert "rmse/layer_0" in scalars
+        assert "projected/layer_0" in projections
 
         # Should NOT have factor keys
-        assert "layer_0_factor_0/r2" not in scalars
-        assert "layer_0_factor_0/projected" not in projections
+        assert "r2/layer_0-F0" not in scalars
+        assert "projected/layer_0-F0" not in projections
 
     def test_linear_regression_concat_belief_states(self, factored_belief_data):
         """LinearRegressionAnalysis with concat_belief_states=True should return both factor and concat results."""
@@ -1074,20 +1074,20 @@ class TestTupleBeliefStates:
         )
 
         # Should have per-factor results
-        assert "layer_0_factor_0/r2" in scalars
-        assert "layer_0_factor_1/r2" in scalars
-        assert "layer_0_factor_0/projected" in projections
-        assert "layer_0_factor_1/projected" in projections
+        assert "r2/layer_0-F0" in scalars
+        assert "r2/layer_0-F1" in scalars
+        assert "projected/layer_0-F0" in projections
+        assert "projected/layer_0-F1" in projections
 
         # Should ALSO have concatenated results
-        assert "layer_0_concat/r2" in scalars
-        assert "layer_0_concat/rmse" in scalars
-        assert "layer_0_concat/projected" in projections
+        assert "r2/layer_0-Fcat" in scalars
+        assert "rmse/layer_0-Fcat" in scalars
+        assert "projected/layer_0-Fcat" in projections
 
         # Check concatenated projection shape (should be sum of factor dimensions)
         batch_size = factored_belief_data["batch_size"]
         total_dim = factored_belief_data["factor_0_dim"] + factored_belief_data["factor_1_dim"]
-        assert projections["layer_0_concat/projected"].shape == (batch_size, total_dim)
+        assert projections["projected/layer_0-Fcat"].shape == (batch_size, total_dim)
 
     def test_three_factor_tuple(self, factored_belief_data):
         """Test with three factors to ensure generalization."""
@@ -1145,10 +1145,10 @@ class TestTupleBeliefStates:
             weights=prepared.weights,
         )
 
-        assert "layer_0_orthogonality_0_1/subspace_overlap" in scalars
-        assert "layer_0_orthogonality_0_1/max_singular_value" in scalars
-        assert "layer_0_orthogonality_0_1/participation_ratio" in scalars
-        assert "layer_0_orthogonality_0_1/effective_rank" in scalars
+        assert "orth/overlap/layer_0-F0,1" in scalars
+        assert "orth/sv_max/layer_0-F0,1" in scalars
+        assert "orth/p_ratio/layer_0-F0,1" in scalars
+        assert "orth/eff_rank/layer_0-F0,1" in scalars
 
         # SVD Linear Regression
         analysis_svd = LinearRegressionSVDAnalysis(
@@ -1162,7 +1162,7 @@ class TestTupleBeliefStates:
             weights=prepared.weights,
         )
 
-        assert "layer_0_orthogonality_0_1/subspace_overlap" in scalars_svd
+        assert "orth/overlap/layer_0-F0,1" in scalars_svd
 
 
 class TestScalarSeriesMapping:

--- a/tests/activations/test_activation_visualizations.py
+++ b/tests/activations/test_activation_visualizations.py
@@ -198,7 +198,7 @@ class TestBuildVisualizationPayloads:
 
     def test_builds_payload_with_projections(self, basic_metadata, basic_viz_config):
         """Test building a payload with projection data."""
-        projections = {"layer_0_pca": np.array([[1.0, 2.0], [3.0, 4.0]])}
+        projections = {"pca/layer_0": np.array([[1.0, 2.0], [3.0, 4.0]])}
         payloads = build_visualization_payloads(
             analysis_name="test",
             viz_cfgs=[basic_viz_config],
@@ -278,7 +278,7 @@ class TestBuildVisualizationPayloads:
                 }
             ),
         ]
-        projections = {"layer_0_pca": np.array([[1.0, 2.0], [3.0, 4.0]])}
+        projections = {"pca/layer_0": np.array([[1.0, 2.0], [3.0, 4.0]])}
         payloads = build_visualization_payloads(
             analysis_name="test",
             viz_cfgs=configs,

--- a/tests/activations/test_dataframe_integration.py
+++ b/tests/activations/test_dataframe_integration.py
@@ -34,8 +34,8 @@ class TestProjectionDataframeIntegration:
         factor_1_data = np.array([[0.5, 0.5], [0.4, 0.6], [0.3, 0.7]])
 
         projections = {
-            "layer_0_factor_0/projected": factor_0_data,
-            "layer_0_factor_1/projected": factor_1_data,
+            "projected/layer_0-F0": factor_0_data,
+            "projected/layer_0-F1": factor_1_data,
         }
 
         # Metadata columns with 3 samples
@@ -49,13 +49,13 @@ class TestProjectionDataframeIntegration:
         mappings = {
             "factor_*_prob_0": ActivationVisualizationFieldRef(
                 source="projections",
-                key="factor_*/projected",
+                key="projected/F*",
                 component=0,
                 group_as="factor",
             ),
             "factor_*_prob_1": ActivationVisualizationFieldRef(
                 source="projections",
-                key="factor_*/projected",
+                key="projected/F*",
                 component=1,
                 group_as="factor",
             ),
@@ -124,8 +124,8 @@ class TestProjectionDataframeIntegration:
         factor_1_data = np.array([[0.5, 0.5], [0.4, 0.6]])  # 2 components
 
         projections = {
-            "layer_0_factor_0/projected": factor_0_data,
-            "layer_0_factor_1/projected": factor_1_data,
+            "projected/layer_0-F0": factor_0_data,
+            "projected/layer_0-F1": factor_1_data,
         }
 
         metadata_columns = {
@@ -137,7 +137,7 @@ class TestProjectionDataframeIntegration:
         mappings = {
             "factor_*_prob_2": ActivationVisualizationFieldRef(
                 source="projections",
-                key="factor_*/projected",
+                key="projected/F*",
                 component=2,
                 group_as="factor",
             ),
@@ -174,8 +174,8 @@ class TestProjectionDataframeIntegration:
         projected_values = belief_states + noise
 
         projections = {
-            "layer_0_factor_0/projected": projected_values[:, 0, :],
-            "layer_0_factor_1/projected": projected_values[:, 1, :],
+            "projected/layer_0-F0": projected_values[:, 0, :],
+            "projected/layer_0-F1": projected_values[:, 1, :],
         }
 
         metadata_columns = {
@@ -194,7 +194,7 @@ class TestProjectionDataframeIntegration:
                         label="prediction",
                         mappings={
                             f"factor_*_prob_{i}": ActivationVisualizationFieldRef(
-                                source="projections", key="factor_*/projected", component=i, group_as="factor"
+                                source="projections", key="projected/F*", component=i, group_as="factor"
                             )
                             for i in range(n_states)
                         },
@@ -238,7 +238,7 @@ class TestProjectionDataframeIntegration:
 
         belief_states = np.random.rand(n_samples, n_factors, n_states)
         projections = {
-            f"layer_{layer_idx}_factor_{factor_idx}/projected": np.random.rand(n_samples, n_states)
+            f"projected/layer_{layer_idx}-F{factor_idx}": np.random.rand(n_samples, n_states)
             for layer_idx in range(n_layers)
             for factor_idx in range(n_factors)
         }
@@ -259,7 +259,7 @@ class TestProjectionDataframeIntegration:
                         label="prediction",
                         mappings={
                             "factor_*_prob_0": ActivationVisualizationFieldRef(
-                                source="projections", key="factor_*/projected", component=0, group_as="factor"
+                                source="projections", key="projected/F*", component=0, group_as="factor"
                             ),
                         },
                     ),
@@ -301,7 +301,7 @@ class TestProjectionDataframeIntegration:
         nf_df = _build_dataframe_for_mappings(
             mappings={"prob_0": ActivationVisualizationFieldRef(source="projections", key="projected", component=0)},
             metadata_columns=metadata,
-            projections={"layer_0_projected": projection_data},
+            projections={"projected/layer_0": projection_data},
             scalars={},
             belief_states=None,
             analysis_concat_layers=False,
@@ -310,11 +310,11 @@ class TestProjectionDataframeIntegration:
         f_df = _build_dataframe_for_mappings(
             mappings={
                 "factor_*_prob_0": ActivationVisualizationFieldRef(
-                    source="projections", key="factor_*/projected", component=0, group_as="factor"
+                    source="projections", key="projected/F*", component=0, group_as="factor"
                 )
             },
             metadata_columns=metadata,
-            projections={"layer_0_factor_0/projected": projection_data},
+            projections={"projected/layer_0-F0": projection_data},
             scalars={},
             belief_states=None,
             analysis_concat_layers=False,
@@ -344,6 +344,6 @@ class TestProjectionDataframeIntegration:
         )
 
         for f in range(n_factors):
-            assert scalars[f"factor_{f}/r2"] > 0.8, f"Factor {f} R² too low"
-            diff = np.abs(np.asarray(projections[f"factor_{f}/projected"]) - np.asarray(belief_states[f]))
+            assert scalars[f"r2/F{f}"] > 0.8, f"Factor {f} R² too low"
+            diff = np.abs(np.asarray(projections[f"projected/F{f}"]) - np.asarray(belief_states[f]))
             assert diff.max() < 0.2, f"Factor {f} projections differ too much from beliefs"

--- a/tests/activations/test_field_expansion.py
+++ b/tests/activations/test_field_expansion.py
@@ -129,14 +129,14 @@ class TestComponentCount:
     def test_get_component_count_projections_2d(self):
         """Test getting component count from 2D projections."""
         ref = ActivationVisualizationFieldRef(source="projections", key="pca")
-        projections = {"layer_0_pca": np.random.randn(100, 10)}
+        projections = {"pca/layer_0": np.random.randn(100, 10)}
         count = _get_component_count(ref, "layer_0", projections, None, False)
         assert count == 10
 
     def test_get_component_count_projections_different_sizes(self):
         """Test getting component count from 2D projections with different sizes."""
         ref = ActivationVisualizationFieldRef(source="projections", key="pca")
-        projections = {"layer_0_pca": np.random.randn(50, 15)}
+        projections = {"pca/layer_0": np.random.randn(50, 15)}
         count = _get_component_count(ref, "layer_0", projections, None, False)
         assert count == 15
 
@@ -150,14 +150,14 @@ class TestComponentCount:
     def test_get_component_count_projections_1d_raises(self):
         """Test that 1D projections raise an error when getting component count."""
         ref = ActivationVisualizationFieldRef(source="projections", key="pca")
-        projections = {"layer_0_pca": np.random.randn(100)}
+        projections = {"pca/layer_0": np.random.randn(100)}
         with pytest.raises(ConfigValidationError, match="1D projection"):
             _get_component_count(ref, "layer_0", projections, None, False)
 
     def test_get_component_count_projections_3d_raises(self):
         """Test that 3D projections raise an error when getting component count."""
         ref = ActivationVisualizationFieldRef(source="projections", key="pca")
-        projections = {"layer_0_pca": np.random.randn(10, 10, 10)}
+        projections = {"pca/layer_0": np.random.randn(10, 10, 10)}
         with pytest.raises(ConfigValidationError, match="1D or 2D"):
             _get_component_count(ref, "layer_0", projections, None, False)
 
@@ -201,7 +201,7 @@ class TestFieldExpansion:
     def test_wildcard_expansion_projections(self):
         """Test detection of wildcard expansion patterns."""
         ref = ActivationVisualizationFieldRef(source="projections", key="pca", component="*")
-        projections = {"layer_0_pca": np.random.randn(50, 3)}
+        projections = {"pca/layer_0": np.random.randn(50, 3)}
 
         expanded = _expand_field_mapping("pc_*", ref, "layer_0", projections, {}, None, False)
 
@@ -232,7 +232,7 @@ class TestFieldExpansion:
     def test_range_expansion(self):
         """Test detection of range expansion patterns."""
         ref = ActivationVisualizationFieldRef(source="projections", key="pca", component="0...5")
-        projections = {"layer_0_pca": np.random.randn(50, 10)}
+        projections = {"pca/layer_0": np.random.randn(50, 10)}
 
         expanded = _expand_field_mapping("pc_0...5", ref, "layer_0", projections, {}, None, False)
 
@@ -246,7 +246,7 @@ class TestFieldExpansion:
     def test_range_expansion_with_offset(self):
         """Test detection of range expansion patterns with offset."""
         ref = ActivationVisualizationFieldRef(source="projections", key="projected", component="2...5")
-        projections = {"layer_0_projected": np.random.randn(50, 10)}
+        projections = {"projected/layer_0": np.random.randn(50, 10)}
 
         expanded = _expand_field_mapping("prob_2...5", ref, "layer_0", projections, {}, None, False)
 
@@ -261,7 +261,7 @@ class TestFieldExpansion:
     def test_wildcard_in_middle_of_name(self):
         """Test detection of wildcard expansion patterns."""
         ref = ActivationVisualizationFieldRef(source="projections", key="pca", component="*")
-        projections = {"layer_0_pca": np.random.randn(50, 3)}
+        projections = {"pca/layer_0": np.random.randn(50, 3)}
 
         expanded = _expand_field_mapping("component_*_normalized", ref, "layer_0", projections, {}, None, False)
 
@@ -273,7 +273,7 @@ class TestFieldExpansion:
     def test_no_expansion_needed(self):
         """Test that no expansion occurs when component is a specific integer."""
         ref = ActivationVisualizationFieldRef(source="projections", key="pca", component=0)
-        projections = {"layer_0_pca": np.random.randn(50, 5)}
+        projections = {"pca/layer_0": np.random.randn(50, 5)}
 
         expanded = _expand_field_mapping("pc_0", ref, "layer_0", projections, {}, None, False)
 
@@ -295,7 +295,7 @@ class TestFieldExpansion:
     def test_field_pattern_without_component_pattern_raises(self):
         """Test that a field pattern without a component pattern raises an error."""
         ref = ActivationVisualizationFieldRef(source="projections", key="pca", component=0)
-        projections = {"layer_0_pca": np.random.randn(50, 5)}
+        projections = {"pca/layer_0": np.random.randn(50, 5)}
 
         with pytest.raises(ConfigValidationError, match="has pattern but component is not"):
             _expand_field_mapping("pc_*", ref, "layer_0", projections, {}, None, False)
@@ -303,7 +303,7 @@ class TestFieldExpansion:
     def test_component_pattern_without_field_pattern_raises(self):
         """Test that a component pattern without a field pattern raises an error."""
         ref = ActivationVisualizationFieldRef(source="projections", key="pca", component="*")
-        projections = {"layer_0_pca": np.random.randn(50, 5)}
+        projections = {"pca/layer_0": np.random.randn(50, 5)}
 
         with pytest.raises(ConfigValidationError, match="requires field name pattern"):
             _expand_field_mapping("pc_0", ref, "layer_0", projections, {}, None, False)
@@ -311,7 +311,7 @@ class TestFieldExpansion:
     def test_range_exceeds_available_components(self):
         """Test that a range exceeding available components raises an error."""
         ref = ActivationVisualizationFieldRef(source="projections", key="pca", component="0...20")
-        projections = {"layer_0_pca": np.random.randn(50, 10)}
+        projections = {"pca/layer_0": np.random.randn(50, 10)}
 
         with pytest.raises(ConfigValidationError, match="exceeds available components"):
             _expand_field_mapping("pc_0...20", ref, "layer_0", projections, {}, None, False)
@@ -319,7 +319,7 @@ class TestFieldExpansion:
     def test_range_partially_exceeds_available_components(self):
         """Test that a range partially exceeding available components raises an error."""
         ref = ActivationVisualizationFieldRef(source="projections", key="pca", component="5...15")
-        projections = {"layer_0_pca": np.random.randn(50, 10)}
+        projections = {"pca/layer_0": np.random.randn(50, 10)}
 
         with pytest.raises(ConfigValidationError, match="exceeds available components"):
             _expand_field_mapping("pc_5...15", ref, "layer_0", projections, {}, None, False)
@@ -500,90 +500,90 @@ class TestPreprocessingFieldExpansion:
 
 
 class TestKeyPatternExpansion:
-    """Test projection key pattern expansion (e.g., factor_*/projected)."""
+    """Test projection key pattern expansion (e.g., projected/F*)."""
 
     def test_has_key_pattern_wildcard(self):
         """Test that _has_key_pattern detects wildcard patterns correctly."""
-        assert _has_key_pattern("factor_*/projected")
-        assert _has_key_pattern("*/projected")
+        assert _has_key_pattern("projected/F*")
+        assert _has_key_pattern("projected/*")
         assert _has_key_pattern("factor_*")
 
     def test_has_key_pattern_range(self):
         """Test that _has_key_pattern detects range patterns correctly."""
-        assert _has_key_pattern("factor_0...3/projected")
-        assert _has_key_pattern("0...5/projected")
+        assert _has_key_pattern("projected/F0...3")
+        assert _has_key_pattern("projected/F0...5")
 
     def test_has_key_pattern_none(self):
         """Test that _has_key_pattern returns False for non-pattern keys."""
         assert not _has_key_pattern(None)
         assert not _has_key_pattern("projected")
-        assert not _has_key_pattern("factor_0/projected")
+        assert not _has_key_pattern("projected/F0")
 
     def test_has_key_pattern_multiple_raises(self):
         """Test that _has_key_pattern raises an error for multiple patterns."""
         with pytest.raises(ConfigValidationError, match="multiple patterns"):
-            _has_key_pattern("factor_*/layer_*/projected")
+            _has_key_pattern("projected/L*/F*")
 
     def test_expand_projection_key_pattern_wildcard(self):
         """Test that _expand_projection_key_pattern expands wildcard patterns correctly."""
         projections = {
-            "layer_0_factor_0/projected": np.random.randn(10, 3),
-            "layer_0_factor_1/projected": np.random.randn(10, 3),
-            "layer_0_factor_2/projected": np.random.randn(10, 3),
+            "projected/layer_0-F0": np.random.randn(10, 3),
+            "projected/layer_0-F1": np.random.randn(10, 3),
+            "projected/layer_0-F2": np.random.randn(10, 3),
         }
 
-        result = _expand_projection_key_pattern("factor_*/projected", "layer_0", projections, False)
+        result = _expand_projection_key_pattern("projected/F*", "layer_0", projections, False)
 
         assert len(result) == 3
-        assert result["0"] == "factor_0/projected"
-        assert result["1"] == "factor_1/projected"
-        assert result["2"] == "factor_2/projected"
+        assert result["0"] == "projected/F0"
+        assert result["1"] == "projected/F1"
+        assert result["2"] == "projected/F2"
 
     def test_expand_projection_key_pattern_range(self):
         """Test that _expand_projection_key_pattern expands range patterns correctly."""
         projections = {
-            "layer_0_factor_0/projected": np.random.randn(10, 3),
-            "layer_0_factor_1/projected": np.random.randn(10, 3),
-            "layer_0_factor_2/projected": np.random.randn(10, 3),
+            "projected/layer_0-F0": np.random.randn(10, 3),
+            "projected/layer_0-F1": np.random.randn(10, 3),
+            "projected/layer_0-F2": np.random.randn(10, 3),
         }
 
-        result = _expand_projection_key_pattern("factor_0...2/projected", "layer_0", projections, False)
+        result = _expand_projection_key_pattern("projected/F0...2", "layer_0", projections, False)
 
         assert len(result) == 2
-        assert result["0"] == "factor_0/projected"
-        assert result["1"] == "factor_1/projected"
+        assert result["0"] == "projected/F0"
+        assert result["1"] == "projected/F1"
 
     def test_expand_projection_key_pattern_concat_layers(self):
         """Test that _expand_projection_key_pattern works with concatenated layers."""
         projections = {
-            "factor_0/projected": np.random.randn(10, 3),
-            "factor_1/projected": np.random.randn(10, 3),
+            "projected/F0": np.random.randn(10, 3),
+            "projected/F1": np.random.randn(10, 3),
         }
 
-        result = _expand_projection_key_pattern("factor_*/projected", "any_layer", projections, True)
+        result = _expand_projection_key_pattern("projected/F*", "any_layer", projections, True)
 
         assert len(result) == 2
-        assert result["0"] == "factor_0/projected"
-        assert result["1"] == "factor_1/projected"
+        assert result["0"] == "projected/F0"
+        assert result["1"] == "projected/F1"
 
     def test_expand_projection_key_pattern_no_matches_raises(self):
         """Test that _expand_projection_key_pattern raises an error when no keys match."""
-        projections = {"layer_0_pca": np.random.randn(10, 3)}
+        projections = {"pca/layer_0": np.random.randn(10, 3)}
 
         with pytest.raises(ConfigValidationError, match="No projection keys found"):
-            _expand_projection_key_pattern("factor_*/projected", "layer_0", projections, False)
+            _expand_projection_key_pattern("projected/F*", "layer_0", projections, False)
 
     def test_field_mapping_with_key_pattern(self):
         """Test that field mappings with key patterns are expanded correctly."""
         ref = ActivationVisualizationFieldRef(
             source="projections",
-            key="factor_*/projected",
+            key="projected/F*",
             component=0,
             group_as="factor",
         )
         projections = {
-            "layer_0_factor_0/projected": np.random.randn(10, 3),
-            "layer_0_factor_1/projected": np.random.randn(10, 3),
+            "projected/layer_0-F0": np.random.randn(10, 3),
+            "projected/layer_0-F1": np.random.randn(10, 3),
         }
 
         expanded = _expand_field_mapping("factor_*_prob", ref, "layer_0", projections, {}, None, False)
@@ -591,8 +591,8 @@ class TestKeyPatternExpansion:
         assert len(expanded) == 2
         assert "factor_0_prob" in expanded
         assert "factor_1_prob" in expanded
-        assert expanded["factor_0_prob"].key == "factor_0/projected"
-        assert expanded["factor_1_prob"].key == "factor_1/projected"
+        assert expanded["factor_0_prob"].key == "projected/F0"
+        assert expanded["factor_1_prob"].key == "projected/F1"
         assert expanded["factor_0_prob"]._group_value == "0"  # pylint: disable=protected-access
         assert expanded["factor_1_prob"]._group_value == "1"  # pylint: disable=protected-access
         assert expanded["factor_0_prob"].group_as == "factor"
@@ -601,13 +601,13 @@ class TestKeyPatternExpansion:
         """Test that field mappings with key and component patterns are expanded correctly."""
         ref = ActivationVisualizationFieldRef(
             source="projections",
-            key="factor_*/projected",
+            key="projected/F*",
             component="*",
             group_as="factor",
         )
         projections = {
-            "layer_0_factor_0/projected": np.random.randn(10, 3),
-            "layer_0_factor_1/projected": np.random.randn(10, 3),
+            "projected/layer_0-F0": np.random.randn(10, 3),
+            "projected/layer_0-F1": np.random.randn(10, 3),
         }
 
         expanded = _expand_field_mapping("factor_*_prob_*", ref, "layer_0", projections, {}, None, False)
@@ -627,8 +627,8 @@ class TestKeyPatternExpansion:
         assert expanded["factor_1_prob_2"].component == 2
 
         # Check that keys and group values are correct
-        assert expanded["factor_0_prob_0"].key == "factor_0/projected"
-        assert expanded["factor_1_prob_0"].key == "factor_1/projected"
+        assert expanded["factor_0_prob_0"].key == "projected/F0"
+        assert expanded["factor_1_prob_0"].key == "projected/F1"
         assert expanded["factor_0_prob_0"]._group_value == "0"  # pylint: disable=protected-access
         assert expanded["factor_1_prob_0"]._group_value == "1"  # pylint: disable=protected-access
 
@@ -636,11 +636,11 @@ class TestKeyPatternExpansion:
         """Test that a key pattern without a field pattern raises an error."""
         ref = ActivationVisualizationFieldRef(
             source="projections",
-            key="factor_*/projected",
+            key="projected/F*",
             component=0,
             group_as="factor",
         )
-        projections = {"layer_0_factor_0/projected": np.random.randn(10, 3)}
+        projections = {"projected/layer_0-F0": np.random.randn(10, 3)}
 
         with pytest.raises(ConfigValidationError, match="requires field name pattern"):
             _expand_field_mapping("prob_0", ref, "layer_0", projections, {}, None, False)
@@ -654,7 +654,7 @@ class TestGroupAsValidation:
         with pytest.raises(ConfigValidationError, match="requires `group_as`"):
             ActivationVisualizationFieldRef(
                 source="projections",
-                key="factor_*/projected",
+                key="projected/F*",
                 component=0,
             )
 
@@ -671,18 +671,18 @@ class TestGroupAsValidation:
         """Test that a valid key pattern with group_as is accepted."""
         ref = ActivationVisualizationFieldRef(
             source="projections",
-            key="factor_*/projected",
+            key="projected/F*",
             component=0,
             group_as="factor",
         )
         assert ref.group_as == "factor"
-        assert ref.key == "factor_*/projected"
+        assert ref.key == "projected/F*"
 
     def test_valid_key_pattern_with_list_group_as(self):
         """Test that a valid key pattern with list group_as is accepted."""
         ref = ActivationVisualizationFieldRef(
             source="projections",
-            key="factor_*/projected",
+            key="projected/F*",
             component=0,
             group_as=["factor", "layer"],
         )

--- a/tests/activations/test_scalar_wildcard_expansion.py
+++ b/tests/activations/test_scalar_wildcard_expansion.py
@@ -12,7 +12,7 @@ class TestScalarWildcardExpansion:
     def test_scalar_no_pattern_returns_identity(self):
         """Scalars without patterns should return as-is."""
         scalars = {"layer_0_rmse": 0.5}
-        result = _expand_scalar_keys("rmse", "layer_0_rmse", "layer_0", scalars)
+        result = _expand_scalar_keys("rmse", "layer_0_rmse", scalars)
 
         assert result == {"rmse": "layer_0_rmse"}
 
@@ -25,7 +25,7 @@ class TestScalarWildcardExpansion:
             "cumvar_3": 0.99,
             "other_metric": 1.0,
         }
-        result = _expand_scalar_keys("cumvar_*", "cumvar_*", "layer_0", scalars)
+        result = _expand_scalar_keys("cumvar_*", "cumvar_*", scalars)
 
         assert len(result) == 4
         assert result == {
@@ -44,7 +44,7 @@ class TestScalarWildcardExpansion:
             "layer_1_cumvar_0": 0.7,
             "other": 1.0,
         }
-        result = _expand_scalar_keys("cv_*", "layer_0_cumvar_*", "layer_0", scalars)
+        result = _expand_scalar_keys("cv_*", "layer_0_cumvar_*", scalars)
 
         assert len(result) == 3
         assert result == {
@@ -62,7 +62,7 @@ class TestScalarWildcardExpansion:
             "cumvar_3": 0.99,
             "cumvar_4": 0.995,
         }
-        result = _expand_scalar_keys("cumvar_1...4", "cumvar_1...4", "layer_0", scalars)
+        result = _expand_scalar_keys("cumvar_1...4", "cumvar_1...4", scalars)
 
         assert len(result) == 3
         assert result == {
@@ -76,14 +76,14 @@ class TestScalarWildcardExpansion:
         scalars = {"other_metric": 1.0}
 
         with pytest.raises(ConfigValidationError, match="No keys found matching pattern"):
-            _expand_scalar_keys("cumvar_*", "cumvar_*", "layer_0", scalars)
+            _expand_scalar_keys("cumvar_*", "cumvar_*", scalars)
 
     def test_scalar_wildcard_requires_key_pattern(self):
         """Wildcard expansion without a key should raise an error."""
         scalars = {"metric": 1.0}
 
         with pytest.raises(ConfigValidationError, match="Scalar wildcard expansion requires a key pattern"):
-            _expand_scalar_keys("field_*", None, "layer_0", scalars)
+            _expand_scalar_keys("field_*", None, scalars)
 
     def test_scalar_expansion_sorts_indices(self):
         """Expanded scalar keys should be sorted by index."""
@@ -93,7 +93,7 @@ class TestScalarWildcardExpansion:
             "var_3": 0.3,
             "var_2": 0.2,
         }
-        result = _expand_scalar_keys("v_*", "var_*", "layer_0", scalars)
+        result = _expand_scalar_keys("v_*", "var_*", scalars)
 
         # Check that keys are in sorted order
         keys = list(result.keys())
@@ -106,7 +106,7 @@ class TestScalarWildcardExpansion:
         scalars = {"metric": 1.0}
 
         # _expand_scalar_keys just returns identity if no pattern in key
-        result = _expand_scalar_keys("field_*", "metric", "layer_0", scalars)
+        result = _expand_scalar_keys("field_*", "metric", scalars)
         assert result == {"field_*": "metric"}
 
     def test_scalar_range_invalid_format_returns_identity(self):
@@ -114,7 +114,7 @@ class TestScalarWildcardExpansion:
         scalars = {"metric_1..4": 1.0}
 
         # Two dots instead of three - not a valid range pattern, returns identity
-        result = _expand_scalar_keys("field_1..4", "metric_1..4", "layer_0", scalars)
+        result = _expand_scalar_keys("field_1..4", "metric_1..4", scalars)
         assert result == {"field_1..4": "metric_1..4"}
 
     def test_scalar_wildcard_with_non_numeric_ignored(self):
@@ -125,7 +125,7 @@ class TestScalarWildcardExpansion:
             "metric_abc": 0.2,
             "metric_xyz": 0.3,
         }
-        result = _expand_scalar_keys("m_*", "metric_*", "layer_0", scalars)
+        result = _expand_scalar_keys("m_*", "metric_*", scalars)
 
         # Only numeric indices should be included
         assert len(result) == 2
@@ -142,7 +142,7 @@ class TestScalarWildcardExpansion:
             "var_01": 0.1,  # This would match as index 1 if not carefully handled
         }
         # This test verifies basic behavior - exact matching prevents this issue
-        result = _expand_scalar_keys("v_*", "var_*", "layer_0", scalars)
+        result = _expand_scalar_keys("v_*", "var_*", scalars)
 
         # Should only match exact numeric patterns
         assert "v_1" in result
@@ -155,7 +155,7 @@ class TestScalarWildcardExpansion:
             "metric_2": 0.2,
             "metric_3": 0.3,
         }
-        result = _expand_scalar_keys("m_0...3", "metric_0...3", "layer_0", scalars)
+        result = _expand_scalar_keys("m_0...3", "metric_0...3", scalars)
 
         assert len(result) == 3
         assert result == {
@@ -172,7 +172,7 @@ class TestScalarWildcardExpansion:
             "layer_0_pca_cumvar_2": 0.95,
             "layer_1_pca_cumvar_0": 0.7,
         }
-        result = _expand_scalar_keys("pc_cv_*", "layer_0_pca_cumvar_*", "layer_0", scalars)
+        result = _expand_scalar_keys("pc_cv_*", "layer_0_pca_cumvar_*", scalars)
 
         assert len(result) == 3
         assert result == {

--- a/tests/activations/test_visualization_modules.py
+++ b/tests/activations/test_visualization_modules.py
@@ -63,7 +63,7 @@ class TestFieldResolution:
 
     def test_lookup_projection_array_not_found(self):
         """Test that missing projection raises error."""
-        projections = {"layer_0_other": np.array([1, 2, 3])}
+        projections = {"other/layer_0": np.array([1, 2, 3])}
         with pytest.raises(ConfigValidationError, match="not available for layer"):
             _lookup_projection_array(projections, "layer_0", "missing", False)
 
@@ -73,9 +73,9 @@ class TestFieldResolution:
         result = _lookup_projection_array(projections, "layer_0", "my_key", True)
         np.testing.assert_array_equal(result, [1, 2, 3])
 
-    def test_lookup_projection_array_concat_layers_suffix_match(self):
-        """Test suffix match with concat_layers."""
-        projections = {"prefix_my_key": np.array([4, 5, 6])}
+    def test_lookup_projection_array_concat_layers_prefix_match(self):
+        """Test prefix match with concat_layers."""
+        projections = {"my_key/Lcat": np.array([4, 5, 6])}
         result = _lookup_projection_array(projections, "layer_0", "my_key", True)
         np.testing.assert_array_equal(result, [4, 5, 6])
 
@@ -85,16 +85,16 @@ class TestFieldResolution:
         result = _lookup_scalar_value(scalars, "layer_0", "my_scalar", True)
         assert result == 0.5
 
-    def test_lookup_scalar_value_concat_layers_suffix(self):
-        """Test scalar lookup with concat_layers suffix match."""
-        scalars = {"prefix_my_scalar": 0.7}
+    def test_lookup_scalar_value_concat_layers_prefix(self):
+        """Test scalar lookup with concat_layers prefix match."""
+        scalars = {"my_scalar/Lcat": 0.7}
         result = _lookup_scalar_value(scalars, "layer_0", "my_scalar", True)
         assert result == 0.7
 
     def test_lookup_scalar_value_not_found(self):
         """Test that missing scalar raises error."""
         with pytest.raises(ConfigValidationError, match="not available for layer"):
-            _lookup_scalar_value({"other": 1.0}, "layer_0", "missing", False)
+            _lookup_scalar_value({"other/layer_0": 1.0}, "layer_0", "missing", False)
 
     def test_maybe_component_1d_with_component(self):
         """Test that 1D array with component raises error."""
@@ -180,7 +180,7 @@ class TestFieldResolution:
     def test_resolve_field_scalars_success(self):
         """Test scalars source returns repeated value."""
         ref = ActivationVisualizationFieldRef(source="scalars", key="my_scalar")
-        scalars = {"layer_0_my_scalar": 0.42}
+        scalars = {"my_scalar/layer_0": 0.42}
         result = _resolve_field(ref, "layer_0", {}, scalars, None, False, 3, {})
         np.testing.assert_array_equal(result, [0.42, 0.42, 0.42])
 
@@ -234,14 +234,14 @@ class TestPatternExpansion:
     def test_get_component_count_projection_success(self):
         """Test getting component count from 2D projection."""
         ref = ActivationVisualizationFieldRef(source="projections", key="proj", component="*")
-        projections = {"layer_0_proj": np.ones((10, 5))}
+        projections = {"proj/layer_0": np.ones((10, 5))}
         result = _get_component_count(ref, "layer_0", projections, None, False)
         assert result == 5
 
     def test_get_component_count_1d_projection(self):
         """Test that 1D projection raises error for expansion."""
         ref = ActivationVisualizationFieldRef(source="projections", key="proj")
-        projections = {"layer_0_proj": np.array([1, 2, 3])}
+        projections = {"proj/layer_0": np.array([1, 2, 3])}
         with pytest.raises(ConfigValidationError, match="Cannot expand 1D"):
             _get_component_count(ref, "layer_0", projections, None, False)
 
@@ -275,7 +275,7 @@ class TestPatternExpansion:
 
     def test_expand_projection_key_pattern_no_matches(self):
         """Test that no matching projections raises error."""
-        projections = {"layer_0_other": np.ones((3, 4))}
+        projections = {"other/layer_0": np.ones((3, 4))}
         with pytest.raises(ConfigValidationError, match="No projection keys found"):
             _expand_projection_key_pattern("key_*", "layer_0", projections, False)
 
@@ -558,12 +558,12 @@ class TestDataframeBuilders:
     def test_infer_scalar_series_indices_success(self):
         """Test inferring scalar series indices from available keys."""
         mapping = ScalarSeriesMapping(
-            key_template="{layer}_cumvar_{index}", index_field="component", value_field="cumvar"
+            key_template="cumvar_{index}/{layer}", index_field="component", value_field="cumvar"
         )
         scalars = {
-            "analysis/layer_0_cumvar_0": 0.5,
-            "analysis/layer_0_cumvar_1": 0.7,
-            "analysis/layer_0_cumvar_2": 0.9,
+            "analysis/cumvar_0/layer_0": 0.5,
+            "analysis/cumvar_1/layer_0": 0.7,
+            "analysis/cumvar_2/layer_0": 0.9,
         }
         result = _infer_scalar_series_indices(mapping, scalars, "layer_0", "analysis")
         assert result == [0, 1, 2]
@@ -571,12 +571,12 @@ class TestDataframeBuilders:
     def test_infer_scalar_series_indices_empty_body(self):
         """Test that empty body between prefix and suffix is skipped."""
         mapping = ScalarSeriesMapping(
-            key_template="{layer}_pc{index}_var", index_field="component", value_field="variance"
+            key_template="pc{index}_var/{layer}", index_field="component", value_field="variance"
         )
         # Key that matches prefix and suffix but has empty body
         scalars = {
-            "analysis/layer_0_pc_var": 0.5,  # Empty between pc and _var
-            "analysis/layer_0_pc0_var": 0.3,
+            "analysis/pc_var/layer_0": 0.5,  # Empty between pc and _var
+            "analysis/pc0_var/layer_0": 0.3,
         }
         result = _infer_scalar_series_indices(mapping, scalars, "layer_0", "analysis")
         assert result == [0]  # Only numeric index included
@@ -584,7 +584,7 @@ class TestDataframeBuilders:
     def test_infer_scalar_series_indices_no_matches(self):
         """Test that no matching indices raises error."""
         mapping = ScalarSeriesMapping(
-            key_template="{layer}_cumvar_{index}", index_field="component", value_field="cumvar"
+            key_template="cumvar_{index}/{layer}", index_field="component", value_field="cumvar"
         )
         scalars = {"analysis/other_metric": 1.0}
         with pytest.raises(ConfigValidationError, match="could not infer indices"):
@@ -593,24 +593,24 @@ class TestDataframeBuilders:
     def test_infer_scalar_series_indices_with_suffix(self):
         """Test inferring indices when template has suffix after index."""
         mapping = ScalarSeriesMapping(
-            key_template="{layer}_pc{index}_var", index_field="component", value_field="variance"
+            key_template="pc{index}_var/{layer}", index_field="component", value_field="variance"
         )
         scalars = {
-            "analysis/layer_0_pc0_var": 0.5,
-            "analysis/layer_0_pc1_var": 0.3,
-            "analysis/layer_0_pc2_var": 0.2,
-            "analysis/layer_0_other": 1.0,  # Should not match
+            "analysis/pc0_var/layer_0": 0.5,
+            "analysis/pc1_var/layer_0": 0.3,
+            "analysis/pc2_var/layer_0": 0.2,
+            "analysis/other/layer_0": 1.0,  # Should not match
         }
         result = _infer_scalar_series_indices(mapping, scalars, "layer_0", "analysis")
         assert result == [0, 1, 2]
 
     def test_infer_scalar_series_indices_non_numeric_skipped(self):
         """Test that non-numeric values are skipped."""
-        mapping = ScalarSeriesMapping(key_template="{layer}_item_{index}", index_field="idx", value_field="val")
+        mapping = ScalarSeriesMapping(key_template="item_{index}/{layer}", index_field="idx", value_field="val")
         scalars = {
-            "analysis/layer_0_item_0": 0.5,
-            "analysis/layer_0_item_abc": 0.7,  # Non-numeric, should be skipped
-            "analysis/layer_0_item_1": 0.9,
+            "analysis/item_0/layer_0": 0.5,
+            "analysis/item_abc/layer_0": 0.7,  # Non-numeric, should be skipped
+            "analysis/item_1/layer_0": 0.9,
         }
         result = _infer_scalar_series_indices(mapping, scalars, "layer_0", "analysis")
         assert result == [0, 1]
@@ -618,13 +618,13 @@ class TestDataframeBuilders:
     def test_build_scalar_series_dataframe_success(self):
         """Test building scalar series dataframe."""
         mapping = ScalarSeriesMapping(
-            key_template="{layer}_cumvar_{index}", index_field="component", value_field="cumvar"
+            key_template="cumvar_{index}/{layer}", index_field="component", value_field="cumvar"
         )
         metadata = {"step": np.array([10]), "analysis": np.array(["pca"])}
         scalars = {
-            "analysis/layer_0_cumvar_0": 0.5,
-            "analysis/layer_0_cumvar_1": 0.7,
-            "analysis/layer_1_cumvar_0": 0.6,
+            "analysis/cumvar_0/layer_0": 0.5,
+            "analysis/cumvar_1/layer_0": 0.7,
+            "analysis/cumvar_0/layer_1": 0.6,
         }
         result = _build_scalar_series_dataframe(mapping, metadata, scalars, ["layer_0", "layer_1"], "analysis")
         assert len(result) == 3
@@ -635,7 +635,7 @@ class TestDataframeBuilders:
     def test_build_scalar_series_dataframe_no_matches(self):
         """Test that no matching scalars raises error."""
         mapping = ScalarSeriesMapping(
-            key_template="{layer}_cumvar_{index}", index_field="component", value_field="cumvar"
+            key_template="cumvar_{index}/{layer}", index_field="component", value_field="cumvar"
         )
         metadata = {"step": np.array([10])}
         scalars = {"analysis/other_metric": 1.0}
@@ -646,13 +646,13 @@ class TestDataframeBuilders:
     def test_build_scalar_series_dataframe_with_explicit_indices(self):
         """Test building scalar series dataframe with explicit index_values."""
         mapping = ScalarSeriesMapping(
-            key_template="{layer}_cumvar_{index}", index_field="component", value_field="cumvar", index_values=[0, 1]
+            key_template="cumvar_{index}/{layer}", index_field="component", value_field="cumvar", index_values=[0, 1]
         )
         metadata = {"step": np.array([10])}
         scalars = {
-            "analysis/layer_0_cumvar_0": 0.5,
-            "analysis/layer_0_cumvar_1": 0.7,
-            "analysis/layer_0_cumvar_2": 0.9,  # Not in index_values, should be skipped
+            "analysis/cumvar_0/layer_0": 0.5,
+            "analysis/cumvar_1/layer_0": 0.7,
+            "analysis/cumvar_2/layer_0": 0.9,  # Not in index_values, should be skipped
         }
         result = _build_scalar_series_dataframe(mapping, metadata, scalars, ["layer_0"], "analysis")
         assert len(result) == 2
@@ -660,10 +660,10 @@ class TestDataframeBuilders:
 
     def test_build_scalar_dataframe_scalar_pattern(self):
         """Test building scalar dataframe with scalar_pattern source."""
-        mappings = {"rmse": ActivationVisualizationFieldRef(source="scalar_pattern", key="layer_*_rmse")}
+        mappings = {"rmse": ActivationVisualizationFieldRef(source="scalar_pattern", key="rmse/layer_*")}
         scalars = {
-            "analysis/layer_0_rmse": 0.1,
-            "analysis/layer_1_rmse": 0.2,
+            "analysis/rmse/layer_0": 0.1,
+            "analysis/rmse/layer_1": 0.2,
         }
         result = _build_scalar_dataframe(mappings, scalars, {}, "analysis", 5)
         assert len(result) == 2
@@ -701,9 +701,9 @@ class TestDataframeBuilders:
         """Test that non-scalar sources are skipped."""
         mappings = {
             "proj": ActivationVisualizationFieldRef(source="projections", key="my_proj"),
-            "rmse": ActivationVisualizationFieldRef(source="scalar_pattern", key="layer_*_rmse"),
+            "rmse": ActivationVisualizationFieldRef(source="scalar_pattern", key="rmse/layer_*"),
         }
-        scalars = {"analysis/layer_0_rmse": 0.1}
+        scalars = {"analysis/rmse/layer_0": 0.1}
         result = _build_scalar_dataframe(mappings, scalars, {}, "analysis", 5)
         # Only scalar_pattern should be in result
         assert "rmse" in result.columns
@@ -730,9 +730,9 @@ class TestDataframeBuilders:
 
     def test_build_scalar_dataframe_no_matching_values(self):
         """Test that no matching values raises error with pattern."""
-        mappings = {"rmse": ActivationVisualizationFieldRef(source="scalar_pattern", key="layer_*_missing")}
+        mappings = {"rmse": ActivationVisualizationFieldRef(source="scalar_pattern", key="missing/layer_*")}
         # Scalars exist but don't match the pattern
-        scalars = {"analysis/layer_0_other": 0.1, "analysis/something_else": 0.2}
+        scalars = {"analysis/other/layer_0": 0.1, "analysis/something_else": 0.2}
         with pytest.raises(ConfigValidationError, match="No scalar pattern keys found"):
             _build_scalar_dataframe(mappings, scalars, {}, "analysis", 5)
 
@@ -758,7 +758,7 @@ class TestDataframeBuilders:
         """Test _build_dataframe_for_mappings with simple projection mapping."""
         mappings = {"x": ActivationVisualizationFieldRef(source="projections", key="pca", component=0)}
         metadata = {"step": np.array([1, 2]), "analysis": np.array(["test", "test"])}
-        projections = {"layer_0_pca": np.array([[0.1, 0.2], [0.3, 0.4]])}
+        projections = {"pca/layer_0": np.array([[0.1, 0.2], [0.3, 0.4]])}
         result = _build_dataframe_for_mappings(mappings, metadata, projections, {}, None, False, ["layer_0"])
         assert "x" in result.columns
         assert "layer" in result.columns
@@ -806,11 +806,11 @@ class TestDataframeBuilders:
     def test_build_dataframe_with_scalar_pattern(self):
         """Test _build_dataframe with scalar_pattern source."""
         data_mapping = ActivationVisualizationDataMapping(
-            mappings={"rmse": ActivationVisualizationFieldRef(source="scalar_pattern", key="layer_*_rmse")}
+            mappings={"rmse": ActivationVisualizationFieldRef(source="scalar_pattern", key="rmse/layer_*")}
         )
         viz_cfg = ActivationVisualizationConfig(name="test", data_mapping=data_mapping)
         metadata = {"step": np.array([1]), "analysis": np.array(["test"])}
-        scalars = {"test/layer_0_rmse": 0.1, "test/layer_1_rmse": 0.2}
+        scalars = {"test/rmse/layer_0": 0.1, "test/rmse/layer_1": 0.2}
         result = _build_dataframe(viz_cfg, metadata, {}, scalars, {}, 10, None, False, ["layer_0", "layer_1"])
         assert "rmse" in result.columns
         assert len(result) == 2
@@ -818,12 +818,12 @@ class TestDataframeBuilders:
     def test_build_dataframe_with_scalar_series(self):
         """Test _build_dataframe with scalar_series source."""
         scalar_series = ScalarSeriesMapping(
-            key_template="{layer}_cumvar_{index}", index_field="component", value_field="cumvar"
+            key_template="cumvar_{index}/{layer}", index_field="component", value_field="cumvar"
         )
         data_mapping = ActivationVisualizationDataMapping(mappings={}, scalar_series=scalar_series)
         viz_cfg = ActivationVisualizationConfig(name="test", data_mapping=data_mapping)
         metadata = {"step": np.array([1]), "analysis": np.array(["test"])}
-        scalars = {"test/layer_0_cumvar_0": 0.5, "test/layer_0_cumvar_1": 0.7}
+        scalars = {"test/cumvar_0/layer_0": 0.5, "test/cumvar_1/layer_0": 0.7}
         result = _build_dataframe(viz_cfg, metadata, {}, scalars, {}, None, None, False, ["layer_0"])
         assert "component" in result.columns
         assert "cumvar" in result.columns
@@ -844,8 +844,8 @@ class TestDataframeBuilders:
         viz_cfg = ActivationVisualizationConfig(name="test", data_mapping=data_mapping)
         metadata = {"step": np.array([1])}
         projections = {
-            "layer_0_pca": np.array([[0.1, 0.2]]),
-            "layer_0_raw": np.array([[0.5, 0.6]]),
+            "pca/layer_0": np.array([[0.1, 0.2]]),
+            "raw/layer_0": np.array([[0.5, 0.6]]),
         }
         result = _build_dataframe(viz_cfg, metadata, projections, {}, {}, None, None, False, ["layer_0"])
         assert "source" in result.columns

--- a/tests/activations/test_visualization_modules.py
+++ b/tests/activations/test_visualization_modules.py
@@ -56,11 +56,6 @@ from simplexity.exceptions import ConfigValidationError
 class TestFieldResolution:
     """Tests for field_resolution.py functions."""
 
-    def test_lookup_projection_array_none_key(self):
-        """Test that None key raises error."""
-        with pytest.raises(ConfigValidationError, match="must supply a `key` value"):
-            _lookup_projection_array({}, "layer_0", None, False)
-
     def test_lookup_projection_array_not_found(self):
         """Test that missing projection raises error."""
         projections = {"other/layer_0": np.array([1, 2, 3])}

--- a/tests/analysis/test_layerwise_analysis.py
+++ b/tests/analysis/test_layerwise_analysis.py
@@ -38,14 +38,14 @@ def test_layerwise_analysis_linear_regression_namespacing(analysis_inputs) -> No
         belief_states=belief_states,
     )
 
-    assert set(scalars) >= {"layer_a_r2", "layer_b_r2"}
+    assert set(scalars) >= {"r2/layer_a", "r2/layer_b"}
     assert set(projections) == {
-        "layer_a_projected",
-        "layer_b_projected",
-        "layer_a_coeffs",
-        "layer_b_coeffs",
-        "layer_a_intercept",
-        "layer_b_intercept",
+        "projected/layer_a",
+        "projected/layer_b",
+        "coeffs/layer_a",
+        "coeffs/layer_b",
+        "intercept/layer_a",
+        "intercept/layer_b",
     }
 
 
@@ -89,9 +89,9 @@ def test_pca_analysis_does_not_require_beliefs(analysis_inputs) -> None:
         weights=weights,
         belief_states=None,
     )
-    assert "layer_a_cumvar_1" in scalars
-    assert "layer_a_n_components_50pct" in scalars
-    assert "layer_a_pca" in projections
+    assert "cumvar_1/layer_a" in scalars
+    assert "n_components_50pct/layer_a" in scalars
+    assert "pca/layer_a" in projections
 
 
 def test_invalid_pca_kwargs() -> None:

--- a/tests/analysis/test_layerwise_analysis.py
+++ b/tests/analysis/test_layerwise_analysis.py
@@ -90,7 +90,7 @@ def test_pca_analysis_does_not_require_beliefs(analysis_inputs) -> None:
         belief_states=None,
     )
     assert "cumvar_1/layer_a" in scalars
-    assert "n_components_50pct/layer_a" in scalars
+    assert "nc_50/layer_a" in scalars
     assert "pca/layer_a" in projections
 
 

--- a/tests/analysis/test_linear_regression.py
+++ b/tests/analysis/test_linear_regression.py
@@ -237,34 +237,34 @@ def test_layer_linear_regression_belief_states_tuple_default() -> None:
     )
 
     # Should have separate metrics for each factor
-    assert "factor_0/r2" in scalars
-    assert "factor_1/r2" in scalars
-    assert "factor_0/rmse" in scalars
-    assert "factor_1/rmse" in scalars
-    assert "factor_0/mae" in scalars
-    assert "factor_1/mae" in scalars
-    assert "factor_0/dist" in scalars
-    assert "factor_1/dist" in scalars
+    assert "r2/F0" in scalars
+    assert "r2/F1" in scalars
+    assert "rmse/F0" in scalars
+    assert "rmse/F1" in scalars
+    assert "mae/F0" in scalars
+    assert "mae/F1" in scalars
+    assert "dist/F0" in scalars
+    assert "dist/F1" in scalars
 
     # Should have separate projections for each factor
-    assert "factor_0/projected" in arrays
-    assert "factor_1/projected" in arrays
+    assert "projected/F0" in arrays
+    assert "projected/F1" in arrays
 
     # Should have separate parameters for each factor
-    assert "factor_0/coeffs" in arrays
-    assert "factor_1/coeffs" in arrays
+    assert "coeffs/F0" in arrays
+    assert "coeffs/F1" in arrays
 
     # Should have separate intercepts for each factor by default
-    assert "factor_0/intercept" in arrays
-    assert "factor_1/intercept" in arrays
+    assert "intercept/F0" in arrays
+    assert "intercept/F1" in arrays
 
     # Check shapes
-    assert arrays["factor_0/projected"].shape == factor_0.shape
-    assert arrays["factor_1/projected"].shape == factor_1.shape
-    assert arrays["factor_0/coeffs"].shape == (x.shape[1], factor_0.shape[1])
-    assert arrays["factor_1/coeffs"].shape == (x.shape[1], factor_1.shape[1])
-    assert arrays["factor_0/intercept"].shape == (1, factor_0.shape[1])
-    assert arrays["factor_1/intercept"].shape == (1, factor_1.shape[1])
+    assert arrays["projected/F0"].shape == factor_0.shape
+    assert arrays["projected/F1"].shape == factor_1.shape
+    assert arrays["coeffs/F0"].shape == (x.shape[1], factor_0.shape[1])
+    assert arrays["coeffs/F1"].shape == (x.shape[1], factor_1.shape[1])
+    assert arrays["intercept/F0"].shape == (1, factor_0.shape[1])
+    assert arrays["intercept/F1"].shape == (1, factor_1.shape[1])
 
 
 def test_layer_linear_regression_svd_belief_states_tuple_default() -> None:
@@ -287,31 +287,31 @@ def test_layer_linear_regression_svd_belief_states_tuple_default() -> None:
 
     # Should have ALL regression metrics for each factor including best_rcond
     for factor in [0, 1]:
-        assert f"factor_{factor}/r2" in scalars
-        assert f"factor_{factor}/rmse" in scalars
-        assert f"factor_{factor}/mae" in scalars
-        assert f"factor_{factor}/dist" in scalars
-        assert f"factor_{factor}/best_rcond" in scalars
+        assert f"r2/F{factor}" in scalars
+        assert f"rmse/F{factor}" in scalars
+        assert f"mae/F{factor}" in scalars
+        assert f"dist/F{factor}" in scalars
+        assert f"best_rcond/F{factor}" in scalars
 
     # Should have separate projections for each factor
-    assert "factor_0/projected" in arrays
-    assert "factor_1/projected" in arrays
+    assert "projected/F0" in arrays
+    assert "projected/F1" in arrays
 
     # Should have separate coefficients for each factor
-    assert "factor_0/coeffs" in arrays
-    assert "factor_1/coeffs" in arrays
+    assert "coeffs/F0" in arrays
+    assert "coeffs/F1" in arrays
 
     # Should have separate intercepts for each factor by default
-    assert "factor_0/intercept" in arrays
-    assert "factor_1/intercept" in arrays
+    assert "intercept/F0" in arrays
+    assert "intercept/F1" in arrays
 
     # Check shapes
-    assert arrays["factor_0/projected"].shape == factor_0.shape
-    assert arrays["factor_1/projected"].shape == factor_1.shape
-    assert arrays["factor_0/coeffs"].shape == (x.shape[1], factor_0.shape[1])
-    assert arrays["factor_1/coeffs"].shape == (x.shape[1], factor_1.shape[1])
-    assert arrays["factor_0/intercept"].shape == (1, factor_0.shape[1])
-    assert arrays["factor_1/intercept"].shape == (1, factor_1.shape[1])
+    assert arrays["projected/F0"].shape == factor_0.shape
+    assert arrays["projected/F1"].shape == factor_1.shape
+    assert arrays["coeffs/F0"].shape == (x.shape[1], factor_0.shape[1])
+    assert arrays["coeffs/F1"].shape == (x.shape[1], factor_1.shape[1])
+    assert arrays["intercept/F0"].shape == (1, factor_0.shape[1])
+    assert arrays["intercept/F1"].shape == (1, factor_1.shape[1])
 
 
 def test_layer_linear_regression_belief_states_tuple_single_factor() -> None:
@@ -373,30 +373,30 @@ def test_orthogonality_with_orthogonal_subspaces() -> None:
     )
 
     # Should have standard factor metrics with perfect fit
-    assert scalars["factor_0/r2"] > 0.99  # Should fit nearly perfectly
-    assert scalars["factor_1/r2"] > 0.99
+    assert scalars["r2/F0"] > 0.99  # Should fit nearly perfectly
+    assert scalars["r2/F1"] > 0.99
 
     # Should have ALL orthogonality metrics
-    assert "orthogonality_0_1/subspace_overlap" in scalars
-    assert "orthogonality_0_1/max_singular_value" in scalars
-    assert "orthogonality_0_1/min_singular_value" in scalars
-    assert "orthogonality_0_1/participation_ratio" in scalars
-    assert "orthogonality_0_1/entropy" in scalars
-    assert "orthogonality_0_1/effective_rank" in scalars
+    assert "orth/overlap/F0,1" in scalars
+    assert "orth/sv_max/F0,1" in scalars
+    assert "orth/sv_min/F0,1" in scalars
+    assert "orth/p_ratio/F0,1" in scalars
+    assert "orth/entropy/F0,1" in scalars
+    assert "orth/eff_rank/F0,1" in scalars
 
     # Compute principled threshold based on machine precision and problem size
     threshold = _compute_orthogonality_threshold(x, factor_0, factor_1)
 
     # Should indicate near-zero overlap (orthogonal by construction)
-    assert scalars["orthogonality_0_1/subspace_overlap"] < threshold
-    assert scalars["orthogonality_0_1/max_singular_value"] < threshold
+    assert scalars["orth/overlap/F0,1"] < threshold
+    assert scalars["orth/sv_max/F0,1"] < threshold
 
     # Should have singular values in arrays
-    assert "orthogonality_0_1/singular_values" in arrays
+    assert "orth/singular_values/F0,1" in arrays
     # Both factors have 2 dimensions, so min(2, 2) = 2 singular values
-    assert arrays["orthogonality_0_1/singular_values"].shape[0] == 2
+    assert arrays["orth/singular_values/F0,1"].shape[0] == 2
     # All singular values should be near zero (orthogonal)
-    assert jnp.all(arrays["orthogonality_0_1/singular_values"] < threshold)
+    assert jnp.all(arrays["orth/singular_values/F0,1"] < threshold)
 
 
 def test_orthogonality_with_aligned_subspaces() -> None:
@@ -427,27 +427,27 @@ def test_orthogonality_with_aligned_subspaces() -> None:
     )
 
     # Should have standard factor metrics with perfect fit
-    assert scalars["factor_0/r2"] > 0.99  # Should fit nearly perfectly
-    assert scalars["factor_1/r2"] > 0.99
+    assert scalars["r2/F0"] > 0.99  # Should fit nearly perfectly
+    assert scalars["r2/F1"] > 0.99
 
     # Should have ALL orthogonality metrics
-    assert "orthogonality_0_1/subspace_overlap" in scalars
-    assert "orthogonality_0_1/max_singular_value" in scalars
-    assert "orthogonality_0_1/min_singular_value" in scalars
-    assert "orthogonality_0_1/participation_ratio" in scalars
-    assert "orthogonality_0_1/entropy" in scalars
-    assert "orthogonality_0_1/effective_rank" in scalars
+    assert "orth/overlap/F0,1" in scalars
+    assert "orth/sv_max/F0,1" in scalars
+    assert "orth/sv_min/F0,1" in scalars
+    assert "orth/p_ratio/F0,1" in scalars
+    assert "orth/entropy/F0,1" in scalars
+    assert "orth/eff_rank/F0,1" in scalars
 
     # Should indicate high overlap (aligned by construction)
-    assert scalars["orthogonality_0_1/subspace_overlap"] > 0.99
-    assert scalars["orthogonality_0_1/max_singular_value"] > 0.99
+    assert scalars["orth/overlap/F0,1"] > 0.99
+    assert scalars["orth/sv_max/F0,1"] > 0.99
 
     # Should have singular values in arrays
-    assert "orthogonality_0_1/singular_values" in arrays
+    assert "orth/singular_values/F0,1" in arrays
     # Both factors have 2 dimensions, so min(2, 2) = 2 singular values
-    assert arrays["orthogonality_0_1/singular_values"].shape[0] == 2
+    assert arrays["orth/singular_values/F0,1"].shape[0] == 2
     # All singular values should be near 1.0 (perfectly aligned)
-    assert jnp.all(arrays["orthogonality_0_1/singular_values"] > 0.99)
+    assert jnp.all(arrays["orth/singular_values/F0,1"] > 0.99)
 
 
 def test_orthogonality_with_three_factors() -> None:
@@ -479,34 +479,34 @@ def test_orthogonality_with_three_factors() -> None:
     )
 
     # Should have standard factor metrics for all three factors
-    assert scalars["factor_0/r2"] > 0.99
-    assert scalars["factor_1/r2"] > 0.99
-    assert scalars["factor_2/r2"] > 0.99
+    assert scalars["r2/F0"] > 0.99
+    assert scalars["r2/F1"] > 0.99
+    assert scalars["r2/F2"] > 0.99
 
     # Compute principled threshold based on machine precision and problem size
     threshold = _compute_orthogonality_threshold(x, factor_0, factor_1, factor_2)
 
     # Should have ALL three pairwise orthogonality combinations
-    pairwise_keys = ["orthogonality_0_1", "orthogonality_0_2", "orthogonality_1_2"]
+    pairwise_keys = ["F0,1", "F0,2", "F1,2"]
     for pair_key in pairwise_keys:
-        assert f"{pair_key}/subspace_overlap" in scalars
-        assert f"{pair_key}/max_singular_value" in scalars
-        assert f"{pair_key}/min_singular_value" in scalars
-        assert f"{pair_key}/participation_ratio" in scalars
-        assert f"{pair_key}/entropy" in scalars
-        assert f"{pair_key}/effective_rank" in scalars
-        assert f"{pair_key}/singular_values" in arrays
+        assert f"orth/overlap/{pair_key}" in scalars
+        assert f"orth/sv_max/{pair_key}" in scalars
+        assert f"orth/sv_min/{pair_key}" in scalars
+        assert f"orth/p_ratio/{pair_key}" in scalars
+        assert f"orth/entropy/{pair_key}" in scalars
+        assert f"orth/eff_rank/{pair_key}" in scalars
+        assert f"orth/singular_values/{pair_key}" in arrays
 
         # All pairs should be orthogonal (near-zero overlap)
-        overlap = scalars[f"{pair_key}/subspace_overlap"]
-        assert overlap < threshold, f"{pair_key} subspace_overlap={overlap} >= threshold={threshold}"
+        overlap = scalars[f"orth/overlap/{pair_key}"]
+        assert overlap < threshold, f"{pair_key} overlap={overlap} >= threshold={threshold}"
 
-        max_sv = scalars[f"{pair_key}/max_singular_value"]
-        assert max_sv < threshold, f"{pair_key} max_singular_value={max_sv} >= threshold={threshold}"
+        max_sv = scalars[f"orth/sv_max/{pair_key}"]
+        assert max_sv < threshold, f"{pair_key} sv_max={max_sv} >= threshold={threshold}"
 
         # Each pair has 2D subspaces, so 2 singular values
-        assert arrays[f"{pair_key}/singular_values"].shape[0] == 2
-        svs = arrays[f"{pair_key}/singular_values"]
+        assert arrays[f"orth/singular_values/{pair_key}"].shape[0] == 2
+        svs = arrays[f"orth/singular_values/{pair_key}"]
         assert jnp.all(svs < threshold), f"{pair_key} singular_values={svs} not all < threshold={threshold}"
 
 
@@ -535,23 +535,23 @@ def test_orthogonality_not_computed_by_default() -> None:
     )
 
     # Should have standard factor metrics
-    assert "factor_0/r2" in scalars
-    assert "factor_1/r2" in scalars
+    assert "r2/F0" in scalars
+    assert "r2/F1" in scalars
 
     # Should NOT have any orthogonality metrics
     orthogonality_keys = [
-        "orthogonality_0_1/subspace_overlap",
-        "orthogonality_0_1/max_singular_value",
-        "orthogonality_0_1/min_singular_value",
-        "orthogonality_0_1/participation_ratio",
-        "orthogonality_0_1/entropy",
-        "orthogonality_0_1/effective_rank",
+        "orth/overlap/F0,1",
+        "orth/sv_max/F0,1",
+        "orth/sv_min/F0,1",
+        "orth/p_ratio/F0,1",
+        "orth/entropy/F0,1",
+        "orth/eff_rank/F0,1",
     ]
     for key in orthogonality_keys:
         assert key not in scalars
 
     # Should NOT have orthogonality singular values in arrays
-    assert "orthogonality_0_1/singular_values" not in arrays
+    assert "orth/singular_values/F0,1" not in arrays
 
 
 def test_orthogonality_warning_for_single_belief_state(caplog: pytest.LogCaptureFixture) -> None:
@@ -582,8 +582,8 @@ def test_orthogonality_warning_for_single_belief_state(caplog: pytest.LogCapture
     assert "projected" in arrays
 
     # Should NOT have orthogonality metrics
-    assert "orthogonality_0_1/subspace_overlap" not in scalars
-    assert "orthogonality_0_1/singular_values" not in arrays
+    assert "orth/overlap/F0,1" not in scalars
+    assert "orth/singular_values/F0,1" not in arrays
 
 
 def test_use_svd_flag_equivalence() -> None:
@@ -688,26 +688,26 @@ def test_use_svd_with_orthogonality() -> None:
     )
 
     # Should have standard factor metrics with SVD
-    assert "factor_0/r2" in scalars
-    assert "factor_1/r2" in scalars
-    assert "factor_0/best_rcond" in scalars
-    assert "factor_1/best_rcond" in scalars
+    assert "r2/F0" in scalars
+    assert "r2/F1" in scalars
+    assert "best_rcond/F0" in scalars
+    assert "best_rcond/F1" in scalars
 
     # Should have orthogonality metrics
-    assert "orthogonality_0_1/subspace_overlap" in scalars
-    assert "orthogonality_0_1/max_singular_value" in scalars
-    assert "orthogonality_0_1/singular_values" in arrays
+    assert "orth/overlap/F0,1" in scalars
+    assert "orth/sv_max/F0,1" in scalars
+    assert "orth/singular_values/F0,1" in arrays
 
     # Compute principled threshold
     threshold = _compute_orthogonality_threshold(x, factor_0, factor_1)
 
     # Should indicate near-zero overlap (orthogonal by construction)
-    assert scalars["orthogonality_0_1/subspace_overlap"] < threshold
-    assert scalars["orthogonality_0_1/max_singular_value"] < threshold
+    assert scalars["orth/overlap/F0,1"] < threshold
+    assert scalars["orth/sv_max/F0,1"] < threshold
 
     # Should have good regression fit
-    assert scalars["factor_0/r2"] > 0.99
-    assert scalars["factor_1/r2"] > 0.99
+    assert scalars["r2/F0"] > 0.99
+    assert scalars["r2/F1"] > 0.99
 
 
 def test_orthogonality_with_different_subspace_dimensions() -> None:
@@ -758,24 +758,24 @@ def test_orthogonality_with_different_subspace_dimensions() -> None:
     )
 
     # Should have standard factor metrics
-    assert scalars["factor_0/r2"] > 0.99
-    assert scalars["factor_1/r2"] > 0.99
+    assert scalars["r2/F0"] > 0.99
+    assert scalars["r2/F1"] > 0.99
 
     # Should have orthogonality metrics
-    assert "orthogonality_0_1/subspace_overlap" in scalars
-    assert "orthogonality_0_1/max_singular_value" in scalars
-    assert "orthogonality_0_1/singular_values" in arrays
+    assert "orth/overlap/F0,1" in scalars
+    assert "orth/sv_max/F0,1" in scalars
+    assert "orth/singular_values/F0,1" in arrays
 
     # Compute principled threshold
     threshold = _compute_orthogonality_threshold(x, factor_0, factor_1)
 
     # Should indicate near-zero overlap (orthogonal by construction)
-    assert scalars["orthogonality_0_1/subspace_overlap"] < threshold
-    assert scalars["orthogonality_0_1/max_singular_value"] < threshold
+    assert scalars["orth/overlap/F0,1"] < threshold
+    assert scalars["orth/sv_max/F0,1"] < threshold
 
     # Singular values shape should be min(2, 5) = 2
-    assert arrays["orthogonality_0_1/singular_values"].shape[0] == 2
-    assert jnp.all(arrays["orthogonality_0_1/singular_values"] < threshold)
+    assert arrays["orth/singular_values/F0,1"].shape[0] == 2
+    assert jnp.all(arrays["orth/singular_values/F0,1"] < threshold)
 
 
 def test_orthogonality_with_contained_subspace() -> None:
@@ -827,23 +827,23 @@ def test_orthogonality_with_contained_subspace() -> None:
     )
 
     # Should have standard factor metrics
-    assert scalars["factor_0/r2"] > 0.99
-    assert scalars["factor_1/r2"] > 0.99
+    assert scalars["r2/F0"] > 0.99
+    assert scalars["r2/F1"] > 0.99
 
     # Should have orthogonality metrics
-    assert "orthogonality_0_1/subspace_overlap" in scalars
-    assert "orthogonality_0_1/max_singular_value" in scalars
-    assert "orthogonality_0_1/singular_values" in arrays
+    assert "orth/overlap/F0,1" in scalars
+    assert "orth/sv_max/F0,1" in scalars
+    assert "orth/singular_values/F0,1" in arrays
 
     # Singular values shape should be min(2, 3) = 2
-    assert arrays["orthogonality_0_1/singular_values"].shape[0] == 2
+    assert arrays["orth/singular_values/F0,1"].shape[0] == 2
 
     # Since factor_0's subspace is contained in factor_1's, singular values should be near 1.0
     # (indicating perfect alignment in the 2D shared subspace)
-    assert scalars["orthogonality_0_1/subspace_overlap"] > 0.99
-    assert scalars["orthogonality_0_1/max_singular_value"] > 0.99
-    assert scalars["orthogonality_0_1/min_singular_value"] > 0.99
-    assert jnp.all(arrays["orthogonality_0_1/singular_values"] > 0.99)
+    assert scalars["orth/overlap/F0,1"] > 0.99
+    assert scalars["orth/sv_max/F0,1"] > 0.99
+    assert scalars["orth/sv_min/F0,1"] > 0.99
+    assert jnp.all(arrays["orth/singular_values/F0,1"] > 0.99)
 
 
 def test_orthogonality_excludes_intercept() -> None:
@@ -876,27 +876,27 @@ def test_orthogonality_excludes_intercept() -> None:
     )
 
     # Should have intercepts for both factors
-    assert "factor_0/intercept" in arrays
-    assert "factor_1/intercept" in arrays
+    assert "intercept/F0" in arrays
+    assert "intercept/F1" in arrays
 
     # Should have good regression fit
-    assert scalars["factor_0/r2"] > 0.99
-    assert scalars["factor_1/r2"] > 0.99
+    assert scalars["r2/F0"] > 0.99
+    assert scalars["r2/F1"] > 0.99
 
     # Orthogonality should still be near-zero (computed from coefficients only, not intercepts)
     threshold = _compute_orthogonality_threshold(x, factor_0, factor_1)
 
-    assert "orthogonality_0_1/subspace_overlap" in scalars
-    assert "orthogonality_0_1/max_singular_value" in scalars
+    assert "orth/overlap/F0,1" in scalars
+    assert "orth/sv_max/F0,1" in scalars
 
-    overlap = scalars["orthogonality_0_1/subspace_overlap"]
-    assert overlap < threshold, f"subspace_overlap={overlap} >= threshold={threshold}"
+    overlap = scalars["orth/overlap/F0,1"]
+    assert overlap < threshold, f"overlap={overlap} >= threshold={threshold}"
 
-    max_sv = scalars["orthogonality_0_1/max_singular_value"]
-    assert max_sv < threshold, f"max_singular_value={max_sv} >= threshold={threshold}"
+    max_sv = scalars["orth/sv_max/F0,1"]
+    assert max_sv < threshold, f"sv_max={max_sv} >= threshold={threshold}"
 
     # The different intercepts should not affect orthogonality
-    svs = arrays["orthogonality_0_1/singular_values"]
+    svs = arrays["orth/singular_values/F0,1"]
     assert jnp.all(svs < threshold), f"singular_values={svs} not all < threshold={threshold}"
 
 
@@ -1004,14 +1004,14 @@ def test_layer_linear_regression_concat_vs_separate_equivalence() -> None:
     )
 
     # Concat path should also provide combined arrays
-    assert "concat/projected" in arrays_cat
-    assert "concat/coeffs" in arrays_cat
-    assert "concat/intercept" in arrays_cat
+    assert "projected/Fcat" in arrays_cat
+    assert "coeffs/Fcat" in arrays_cat
+    assert "intercept/Fcat" in arrays_cat
 
     # Per-factor arrays should match between separate and concatenated flows
     for k in ["projected", "coeffs", "intercept"]:
-        chex.assert_trees_all_close(arrays_sep[f"factor_0/{k}"], arrays_cat[f"factor_0/{k}"])
-        chex.assert_trees_all_close(arrays_sep[f"factor_1/{k}"], arrays_cat[f"factor_1/{k}"])
+        chex.assert_trees_all_close(arrays_sep[f"{k}/F0"], arrays_cat[f"{k}/F0"])
+        chex.assert_trees_all_close(arrays_sep[f"{k}/F1"], arrays_cat[f"{k}/F1"])
 
 
 def test_layer_linear_regression_svd_concat_vs_separate_equivalence_best_rcond() -> None:
@@ -1055,34 +1055,34 @@ def test_layer_linear_regression_svd_concat_vs_separate_equivalence_best_rcond()
     )
 
     # Concat path should provide combined arrays and best_rcond
-    assert "concat/projected" in arrays_cat
-    assert "concat/coeffs" in arrays_cat
-    assert "concat/intercept" in arrays_cat
-    assert "concat/best_rcond" in scalars_cat
-    assert scalars_cat["concat/best_rcond"] == pytest.approx(1e-3)
+    assert "projected/Fcat" in arrays_cat
+    assert "coeffs/Fcat" in arrays_cat
+    assert "intercept/Fcat" in arrays_cat
+    assert "best_rcond/Fcat" in scalars_cat
+    assert scalars_cat["best_rcond/Fcat"] == pytest.approx(1e-3)
 
     # Separate path should include per-factor best_rcond; concat-split path should not
-    assert "factor_0/best_rcond" in scalars_sep
-    assert "factor_1/best_rcond" in scalars_sep
-    assert "factor_0/best_rcond" not in scalars_cat
-    assert "factor_1/best_rcond" not in scalars_cat
+    assert "best_rcond/F0" in scalars_sep
+    assert "best_rcond/F1" in scalars_sep
+    assert "best_rcond/F0" not in scalars_cat
+    assert "best_rcond/F1" not in scalars_cat
 
     # Per-factor arrays should match between separate and concat-split flows
     for k in ["projected", "coeffs", "intercept"]:
-        chex.assert_trees_all_close(arrays_sep[f"factor_0/{k}"], arrays_cat[f"factor_0/{k}"])
-        chex.assert_trees_all_close(arrays_sep[f"factor_1/{k}"], arrays_cat[f"factor_1/{k}"])
+        chex.assert_trees_all_close(arrays_sep[f"{k}/F0"], arrays_cat[f"{k}/F0"])
+        chex.assert_trees_all_close(arrays_sep[f"{k}/F1"], arrays_cat[f"{k}/F1"])
 
     # Overlapping scalar metrics should agree closely across flows
     for metric in ["r2", "rmse", "mae", "dist"]:
         assert jnp.isclose(
-            jnp.asarray(scalars_sep[f"factor_0/{metric}"]),
-            jnp.asarray(scalars_cat[f"factor_0/{metric}"]),
+            jnp.asarray(scalars_sep[f"{metric}/F0"]),
+            jnp.asarray(scalars_cat[f"{metric}/F0"]),
             atol=1e-6,
             rtol=0.0,
         ).item()
         assert jnp.isclose(
-            jnp.asarray(scalars_sep[f"factor_1/{metric}"]),
-            jnp.asarray(scalars_cat[f"factor_1/{metric}"]),
+            jnp.asarray(scalars_sep[f"{metric}/F1"]),
+            jnp.asarray(scalars_cat[f"{metric}/F1"]),
             atol=1e-6,
             rtol=0.0,
         ).item()

--- a/tests/analysis/test_metric_keys.py
+++ b/tests/analysis/test_metric_keys.py
@@ -1,0 +1,53 @@
+"""Tests for the metric key construction utility functions."""
+
+from simplexity.analysis.metric_keys import construct_layer_specific_key, format_layer_spec
+
+def test_construct_layer_specific_key_given_factor_specific_key() -> None:
+    """Test that the function adds layer name before the factor-specific key."""
+    key = "rmse/F0"
+    layer_name = "L1.resid.post"
+    expected_key = "rmse/L1.resid.post-F0"
+    assert construct_layer_specific_key(key, layer_name) == expected_key
+
+def test_construct_layer_specific_key_given_non_factor_specific_key() -> None:
+    """Test that the function adds layer name before the non-factor-specific key."""
+    key = "r2"
+    layer_name = "L1.resid.post"
+    expected_key = "r2/L1.resid.post"
+    assert construct_layer_specific_key(key, layer_name) == expected_key
+
+def test_format_layer_spec_concatenated() -> None:
+    """Test that the function returns the correct format for concatenated layers."""
+    layer_name = "concatenated"
+    expected_key = "Lcat"
+    assert format_layer_spec(layer_name) == expected_key
+
+def test_format_layer_spec_block_and_hook_layer() -> None:
+    """Test that the function returns the correct format for block and hook layer name."""
+    layer_name = "blocks.2.hook_resid_post"
+    expected_key = "L2.resid.post"
+    assert format_layer_spec(layer_name) == expected_key
+
+def test_format_layer_spec_special_layer() -> None:
+    """Test that the function returns the correct format for special layer name."""
+    layer_name = "embed"
+    expected_key = "embed"
+    assert format_layer_spec(layer_name) == expected_key
+
+def test_format_layer_spec_block_layer_with_no_hook_name() -> None:
+    """Test that the function returns the input layer name if it is a block layer name with no hook name."""
+    layer_name = "blocks.2"
+    expected_key = "blocks.2"
+    assert format_layer_spec(layer_name) == expected_key
+
+def test_format_layer_spec_block_and_hook_layer_with_no_block_number() -> None:
+    """Test that the function returns the input layer name if it is a block and hook layer name with no block number."""
+    layer_name = "blocks.hook_resid_post"
+    expected_key = "blocks.hook_resid_post"
+    assert format_layer_spec(layer_name) == expected_key
+
+def test_format_layer_spec_block_and_hook_layer_with_extra_structure() -> None:
+    """Test that the function returns the correct format if it is a block and hook layer name with extra structure."""
+    layer_name = "blocks.2.hook_resid_post.invalid"
+    expected_key = "L2.resid.post.invalid"
+    assert format_layer_spec(layer_name) == expected_key

--- a/tests/analysis/test_metric_keys.py
+++ b/tests/analysis/test_metric_keys.py
@@ -2,12 +2,14 @@
 
 from simplexity.analysis.metric_keys import construct_layer_specific_key, format_layer_spec
 
+
 def test_construct_layer_specific_key_given_factor_specific_key() -> None:
     """Test that the function adds layer name before the factor-specific key."""
     key = "rmse/F0"
     layer_name = "L1.resid.post"
     expected_key = "rmse/L1.resid.post-F0"
     assert construct_layer_specific_key(key, layer_name) == expected_key
+
 
 def test_construct_layer_specific_key_given_non_factor_specific_key() -> None:
     """Test that the function adds layer name before the non-factor-specific key."""
@@ -16,11 +18,13 @@ def test_construct_layer_specific_key_given_non_factor_specific_key() -> None:
     expected_key = "r2/L1.resid.post"
     assert construct_layer_specific_key(key, layer_name) == expected_key
 
+
 def test_format_layer_spec_concatenated() -> None:
     """Test that the function returns the correct format for concatenated layers."""
     layer_name = "concatenated"
     expected_key = "Lcat"
     assert format_layer_spec(layer_name) == expected_key
+
 
 def test_format_layer_spec_block_and_hook_layer() -> None:
     """Test that the function returns the correct format for block and hook layer name."""
@@ -28,11 +32,13 @@ def test_format_layer_spec_block_and_hook_layer() -> None:
     expected_key = "L2.resid.post"
     assert format_layer_spec(layer_name) == expected_key
 
+
 def test_format_layer_spec_special_layer() -> None:
     """Test that the function returns the correct format for special layer name."""
     layer_name = "embed"
     expected_key = "embed"
     assert format_layer_spec(layer_name) == expected_key
+
 
 def test_format_layer_spec_block_layer_with_no_hook_name() -> None:
     """Test that the function returns the input layer name if it is a block layer name with no hook name."""
@@ -40,11 +46,13 @@ def test_format_layer_spec_block_layer_with_no_hook_name() -> None:
     expected_key = "blocks.2"
     assert format_layer_spec(layer_name) == expected_key
 
+
 def test_format_layer_spec_block_and_hook_layer_with_no_block_number() -> None:
     """Test that the function returns the input layer name if it is a block and hook layer name with no block number."""
     layer_name = "blocks.hook_resid_post"
     expected_key = "blocks.hook_resid_post"
     assert format_layer_spec(layer_name) == expected_key
+
 
 def test_format_layer_spec_block_and_hook_layer_with_extra_structure() -> None:
     """Test that the function returns the correct format if it is a block and hook layer name with extra structure."""

--- a/tests/analysis/test_pca.py
+++ b/tests/analysis/test_pca.py
@@ -39,7 +39,7 @@ def test_layer_pca_analysis_metrics() -> None:
         variance_thresholds=(0.5,),
     )
     assert "cumvar_1" in scalars
-    assert "n_components_50pct" in scalars
+    assert "nc_50" in scalars
     assert "pca" in projections
     assert projections["pca"].shape == (3, 2)
 
@@ -100,7 +100,7 @@ def test_layer_pca_analysis_zero_variance_threshold_reporting() -> None:
         belief_states=None,
         variance_thresholds=(0.5,),
     )
-    assert scalars["n_components_50pct"] == 3.0
+    assert scalars["nc_50"] == 3.0
     assert projections["pca"].shape == (4, 3)
 
 

--- a/tests/end_to_end/configs/activation_tracker/with_visuals.yaml
+++ b/tests/end_to_end/configs/activation_tracker/with_visuals.yaml
@@ -48,7 +48,7 @@ instance:
             cumulative: false
           data_mapping:
             scalar_series:
-              key_template: "{layer}_cumvar_{index}"
+              key_template: "cumvar_{index}/{layer}"
               index_field: n_components
               value_field: cumulative_explained_variance
           backend: altair
@@ -173,7 +173,7 @@ instance:
             dropdown: layer  # User can filter by layer in UI
           data_mapping:
             mappings:
-              rmse: {source: scalar_pattern, key: "blocks.*.hook_resid_post_rmse"}  # Wildcard expands to all layers
+              rmse: {source: scalar_pattern, key: "rmse/L*.resid.post"}  # Wildcard expands to all layers
           backend: altair
           layer:
             geometry:

--- a/tests/structured_configs/test_activation_tracker_config.py
+++ b/tests/structured_configs/test_activation_tracker_config.py
@@ -256,7 +256,7 @@ def test_instantiate_activation_tracker_builds_analysis_objects(tracker_cfg: Dic
         probs=probs,
         activations=activations,
     )
-    assert "pca_custom/layer_cumvar_1" in scalars
+    assert "pca_custom/cumvar_1/layer" in scalars
     assert any(key.startswith("linear/") for key in projections)
     assert visualizations == {}
 


### PR DESCRIPTION
## Summary

Implements the metric naming convention changes proposed in #146 to improve MLflow metric navigation and scalability.

**Problem**: The existing naming convention (`{analysis_type}/{layer}_{metric}` or `{analysis_type}/[{layer}_{subtype}_{factor}/]{metric}`) creates unwieldy folder names (40+ characters), poor information hierarchy, and folder explosion that scales primarily with `layers × factors`.

**Solution**: Restructure keys to `{analysis_type}[/{subtype}...]/{metric}[/{layer}-{factor}]` format so folders scale primarily with `metric_types`, and abbreviate verbose names for scannability.

## Key Format Changes

| Category | Before | After |
|----------|--------|-------|
| Layer names | `blocks.0.hook_resid_pre` | `L0.resid.pre` |
| Key structure | `layer_metric` | `metric/layer` |
| Factor keys | `factor_0/r2` | `r2/F0` |
| Concatenated | `concat/projected` | `projected/Fcat` |
| Orthogonality | `orthogonality_0_1/subspace_overlap` | `orth/overlap/F0,1` |

## Metric Abbreviations

| Before | After |
|--------|-------|
| `subspace_overlap` | `overlap` |
| `max_singular_value` | `sv_max` |
| `min_singular_value` | `sv_min` |
| `participation_ratio` | `p_ratio` |
| `effective_rank` | `eff_rank` |
| `variance_explained` | `var_exp` |
| `n_components_95pct` | `nc_95` |

## Changes

### New module: `simplexity/analysis/metric_keys.py`
- `format_layer_spec()`: Converts verbose layer names to compact form
- `construct_layer_specific_key()`: Builds full keys with layer suffix

### Updated modules
- `layerwise_analysis.py`: Integrates new key formatting
- `linear_regression.py`: Abbreviated orthogonality metric names
- `pca.py`: Abbreviated metric names
- `field_resolution.py`: Updated lookups to format layer names before matching
- `dataframe_builders.py`: Updated scalar series inference for new format

## Test plan
- [x] All 1128 tests passing
- [x] Visualization key lookups work with formatted layer names
- [x] Scalar series inference matches new key format

Resolves #146