### PR TITLE
reduce number of metrics returned from variance analysis

### DIFF
--- a/simplexity/activations/activation_analyses.py
+++ b/simplexity/activations/activation_analyses.py
@@ -42,7 +42,7 @@ class ActivationAnalysis(Protocol):
         weights: jax.Array,
         belief_states: jax.Array | tuple[jax.Array, ...] | None = None,
     ) -> tuple[Mapping[str, float], Mapping[str, jax.Array]]:
-        """Analyze activations and return scalar metrics and projections."""
+        """Analyze activations and return scalar metrics and arrays."""
         ...
 
 

--- a/simplexity/activations/activation_tracker.py
+++ b/simplexity/activations/activation_tracker.py
@@ -182,7 +182,7 @@ class ActivationTracker:
                 preprocessing_cache[config_key] = prepared
 
         all_scalars = {}
-        all_projections = {}
+        all_arrays = {}
         all_visualizations: dict[str, ActivationVisualizationPayload] = {}
 
         for analysis_name, analysis in self._analyses.items():
@@ -203,7 +203,7 @@ class ActivationTracker:
                     f"Analysis '{analysis_name}' requires belief_states but none available after preprocessing."
                 )
 
-            scalars, projections = analysis.analyze(
+            scalars, arrays = analysis.analyze(
                 activations=prepared_activations,
                 weights=prepared_weights,
                 belief_states=prepared_beliefs,
@@ -211,7 +211,7 @@ class ActivationTracker:
 
             namespaced_scalars = {f"{analysis_name}/{key}": value for key, value in scalars.items()}
             all_scalars.update(namespaced_scalars)
-            all_projections.update({f"{analysis_name}/{key}": value for key, value in projections.items()})
+            all_arrays.update({f"{analysis_name}/{key}": value for key, value in arrays.items()})
 
             if step is not None:
                 for scalar_key, scalar_value in namespaced_scalars.items():
@@ -230,7 +230,7 @@ class ActivationTracker:
                     np_beliefs = np.stack([np.asarray(b) for b in prepared_beliefs], axis=1)
                 else:
                     np_beliefs = np.asarray(prepared_beliefs)
-                np_projections = {key: np.asarray(value) for key, value in projections.items()}
+                np_arrays = {key: np.asarray(value) for key, value in arrays.items()}
                 payloads = build_visualization_payloads(
                     analysis_name,
                     viz_configs,
@@ -238,7 +238,7 @@ class ActivationTracker:
                     prepared_metadata=prepared.metadata,
                     weights=np_weights,
                     belief_states=np_beliefs,
-                    projections=np_projections,
+                    arrays=np_arrays,
                     scalars={f"{analysis_name}/{key}": float(value) for key, value in scalars.items()},
                     scalar_history=self._scalar_history,
                     scalar_history_step=step,
@@ -247,7 +247,7 @@ class ActivationTracker:
                 )
                 all_visualizations.update({f"{analysis_name}/{payload.name}": payload for payload in payloads})
 
-        return all_scalars, all_projections, all_visualizations
+        return all_scalars, all_arrays, all_visualizations
 
     def save_visualizations(
         self,

--- a/simplexity/activations/activation_visualizations.py
+++ b/simplexity/activations/activation_visualizations.py
@@ -165,7 +165,7 @@ def build_visualization_payloads(
     prepared_metadata: PreparedMetadata,
     weights: np.ndarray,
     belief_states: np.ndarray | None,
-    projections: Mapping[str, np.ndarray],
+    arrays: Mapping[str, np.ndarray],
     scalars: Mapping[str, float],
     scalar_history: Mapping[str, list[tuple[int, float]]],
     scalar_history_step: int | None,
@@ -179,7 +179,7 @@ def build_visualization_payloads(
         dataframe = _build_dataframe(
             viz_cfg,
             metadata_columns,
-            projections,
+            arrays,
             scalars,
             scalar_history,
             scalar_history_step,

--- a/simplexity/activations/visualization/__init__.py
+++ b/simplexity/activations/visualization/__init__.py
@@ -12,7 +12,7 @@ from simplexity.activations.visualization.dataframe_builders import (
     _build_metadata_columns,
 )
 from simplexity.activations.visualization.field_resolution import (
-    _lookup_projection_array,
+    _lookup_array,
     _lookup_scalar_value,
     _maybe_component,
     _resolve_belief_states,
@@ -40,7 +40,7 @@ __all__ = [
     "_expand_field_mapping",
     "_has_field_pattern",
     "_has_key_pattern",
-    "_lookup_projection_array",
+    "_lookup_array",
     "_lookup_scalar_value",
     "_maybe_component",
     "_parse_component_spec",

--- a/simplexity/activations/visualization/dataframe_builders.py
+++ b/simplexity/activations/visualization/dataframe_builders.py
@@ -227,7 +227,7 @@ def _scalar_series_metadata(metadata_columns: Mapping[str, Any]) -> dict[str, An
 def _build_dataframe_for_mappings(
     mappings: dict[str, ActivationVisualizationFieldRef],
     metadata_columns: Mapping[str, Any],
-    projections: Mapping[str, np.ndarray],
+    arrays: Mapping[str, np.ndarray],
     scalars: Mapping[str, float],
     belief_states: np.ndarray | None,
     analysis_concat_layers: bool,
@@ -247,7 +247,7 @@ def _build_dataframe_for_mappings(
         for field_name, ref in mappings.items():
             try:
                 expanded = _expand_field_mapping(
-                    field_name, ref, layer_name, projections, scalars, belief_states, analysis_concat_layers
+                    field_name, ref, layer_name, arrays, scalars, belief_states, analysis_concat_layers
                 )
                 expanded_mappings.update(expanded)
             except ConfigValidationError as e:
@@ -292,7 +292,7 @@ def _build_dataframe_for_mappings(
                     group_data[column] = _resolve_field(
                         ref,
                         layer_name,
-                        projections,
+                        arrays,
                         scalars,
                         belief_states,
                         analysis_concat_layers,
@@ -306,7 +306,7 @@ def _build_dataframe_for_mappings(
                     group_data[base_col_name] = _resolve_field(
                         ref,
                         layer_name,
-                        projections,
+                        arrays,
                         scalars,
                         belief_states,
                         analysis_concat_layers,
@@ -324,7 +324,7 @@ def _build_dataframe_for_mappings(
                 layer_data[column] = _resolve_field(
                     ref,
                     layer_name,
-                    projections,
+                    arrays,
                     scalars,
                     belief_states,
                     analysis_concat_layers,
@@ -339,7 +339,7 @@ def _build_dataframe_for_mappings(
 def _build_dataframe(
     viz_cfg: ActivationVisualizationConfig,
     metadata_columns: Mapping[str, Any],
-    projections: Mapping[str, np.ndarray],
+    arrays: Mapping[str, np.ndarray],
     scalars: Mapping[str, float],
     scalar_history: Mapping[str, list[tuple[int, float]]],
     scalar_history_step: int | None,
@@ -358,7 +358,7 @@ def _build_dataframe(
             section_df = _build_dataframe_for_mappings(
                 section.mappings,
                 metadata_columns,
-                projections,
+                arrays,
                 scalars,
                 belief_states,
                 analysis_concat_layers,
@@ -406,7 +406,7 @@ def _build_dataframe(
     return _build_dataframe_for_mappings(
         viz_cfg.data_mapping.mappings,
         metadata_columns,
-        projections,
+        arrays,
         scalars,
         belief_states,
         analysis_concat_layers,

--- a/simplexity/activations/visualization/field_resolution.py
+++ b/simplexity/activations/visualization/field_resolution.py
@@ -1,4 +1,4 @@
-"""Field resolution from projections, scalars, and belief states."""
+"""Field resolution from arrays, scalars, and belief states."""
 
 from __future__ import annotations
 
@@ -10,14 +10,14 @@ from simplexity.activations.visualization_configs import ActivationVisualization
 from simplexity.exceptions import ConfigValidationError
 
 
-def _lookup_projection_array(
-    projections: Mapping[str, np.ndarray], layer_name: str, key: str | None, concat_layers: bool
+def _lookup_array(
+    arrays: Mapping[str, np.ndarray], layer_name: str, key: str | None, concat_layers: bool
 ) -> np.ndarray:
-    """Look up a projection array by key, handling layer naming conventions."""
+    """Look up an array by key, handling layer naming conventions."""
     if key is None:
-        raise ConfigValidationError("Projection references must supply a `key` value.")
+        raise ConfigValidationError("Array references must supply a `key` value.")
     suffix = f"_{key}"
-    for full_key, value in projections.items():
+    for full_key, value in arrays.items():
         if concat_layers:
             if full_key.endswith(suffix) or full_key == key:
                 return np.asarray(value)
@@ -27,7 +27,7 @@ def _lookup_projection_array(
             candidate_layer = full_key[: -len(suffix)]
             if candidate_layer == layer_name:
                 return np.asarray(value)
-    raise ConfigValidationError(f"Projection '{key}' not available for layer '{layer_name}'.")
+    raise ConfigValidationError(f"Array '{key}' not available for layer '{layer_name}'.")
 
 
 def _lookup_scalar_value(scalars: Mapping[str, float], layer_name: str, key: str, concat_layers: bool) -> float:
@@ -107,7 +107,7 @@ def _resolve_belief_states(belief_states: np.ndarray, ref: ActivationVisualizati
 def _resolve_field(
     ref: ActivationVisualizationFieldRef,
     layer_name: str,
-    projections: Mapping[str, np.ndarray],
+    arrays: Mapping[str, np.ndarray],
     scalars: Mapping[str, float],
     belief_states: np.ndarray | None,
     analysis_concat_layers: bool,
@@ -130,7 +130,7 @@ def _resolve_field(
         return np.asarray(metadata_columns["weight"])
 
     if ref.source == "projections":
-        array = _lookup_projection_array(projections, layer_name, ref.key, analysis_concat_layers)
+        array = _lookup_array(arrays, layer_name, ref.key, analysis_concat_layers)
         if isinstance(ref.component, str):
             raise ConfigValidationError("Component indices should be expanded before resolution")
         return _maybe_component(array, ref.component)
@@ -150,7 +150,7 @@ def _resolve_field(
 
 
 __all__ = [
-    "_lookup_projection_array",
+    "_lookup_array",
     "_lookup_scalar_value",
     "_maybe_component",
     "_resolve_belief_states",

--- a/simplexity/activations/visualization/pattern_expansion.py
+++ b/simplexity/activations/visualization/pattern_expansion.py
@@ -111,7 +111,7 @@ def _get_component_count(
     """Get number of components available for expansion."""
     if ref.source == "arrays":
         if ref.key is None:
-            raise ConfigValidationError("Projection refs require key")
+            raise ConfigValidationError("Array refs require key")
         array = _lookup_array(arrays, layer_name, ref.key, analysis_concat_layers)
         np_array = np.asarray(array)
         if np_array.ndim == 1:

--- a/simplexity/activations/visualization/pattern_expansion.py
+++ b/simplexity/activations/visualization/pattern_expansion.py
@@ -7,7 +7,7 @@ from collections.abc import Iterable, Mapping
 
 import numpy as np
 
-from simplexity.activations.visualization.field_resolution import _lookup_projection_array
+from simplexity.activations.visualization.field_resolution import _lookup_array
 from simplexity.activations.visualization.pattern_utils import (
     build_wildcard_regex,
     count_patterns,
@@ -103,7 +103,7 @@ def _expand_pattern_to_indices(
 def _get_component_count(
     ref: ActivationVisualizationFieldRef,
     layer_name: str,
-    projections: Mapping[str, np.ndarray],
+    arrays: Mapping[str, np.ndarray],
     belief_states: np.ndarray | None,
     analysis_concat_layers: bool,
 ) -> int:
@@ -111,7 +111,7 @@ def _get_component_count(
     if ref.source == "projections":
         if ref.key is None:
             raise ConfigValidationError("Projection refs require key")
-        array = _lookup_projection_array(projections, layer_name, ref.key, analysis_concat_layers)
+        array = _lookup_array(arrays, layer_name, ref.key, analysis_concat_layers)
         np_array = np.asarray(array)
         if np_array.ndim == 1:
             raise ConfigValidationError(f"Cannot expand 1D projection '{ref.key}'. Patterns require 2D arrays.")
@@ -134,7 +134,7 @@ def _get_component_count(
 def _expand_projection_key_pattern(
     key_pattern: str,
     layer_name: str,
-    projections: Mapping[str, np.ndarray],
+    arrays: Mapping[str, np.ndarray],
     analysis_concat_layers: bool,
 ) -> dict[str, str]:
     """Expand projection key patterns against available keys.
@@ -142,7 +142,7 @@ def _expand_projection_key_pattern(
     Args:
         key_pattern: Pattern like "factor_*/projected" or "factor_0...3/projected"
         layer_name: Current layer name for matching
-        projections: Available projection arrays
+        arrays: Available arrays
         analysis_concat_layers: Whether layers were concatenated
 
     Returns:
@@ -167,9 +167,9 @@ def _expand_projection_key_pattern(
             result[str(idx)] = concrete_key
         return result
 
-    # Match against available projection keys
+    # Match against available arrays
     result: dict[str, str] = {}
-    for full_key in projections:
+    for full_key in arrays:
         # Extract the key suffix (part after layer name)
         if analysis_concat_layers:
             # Keys are like "factor_0/projected" directly
@@ -189,8 +189,8 @@ def _expand_projection_key_pattern(
 
     if not result:
         raise ConfigValidationError(
-            f"No projection keys found matching pattern '{key_pattern}' for layer '{layer_name}'. "
-            f"Available keys: {list(projections.keys())}"
+            f"No array keys found matching pattern '{key_pattern}' for layer '{layer_name}'. "
+            f"Available keys: {list(arrays.keys())}"
         )
 
     return result
@@ -200,7 +200,7 @@ def _expand_projection_key_mapping(
     field_name: str,
     ref: ActivationVisualizationFieldRef,
     layer_name: str,
-    projections: Mapping[str, np.ndarray],
+    arrays: Mapping[str, np.ndarray],
     belief_states: np.ndarray | None,
     analysis_concat_layers: bool,
 ) -> dict[str, ActivationVisualizationFieldRef]:
@@ -212,7 +212,7 @@ def _expand_projection_key_mapping(
     assert ref.key is not None, "Key must be provided for projection key pattern expansion"
 
     # Expand key pattern to get concrete keys
-    key_expansions = _expand_projection_key_pattern(ref.key, layer_name, projections, analysis_concat_layers)
+    key_expansions = _expand_projection_key_pattern(ref.key, layer_name, arrays, analysis_concat_layers)
 
     # Check if component expansion is also needed
     spec_type, start_idx, end_idx = _parse_component_spec(ref.component)
@@ -226,7 +226,7 @@ def _expand_projection_key_mapping(
     for group_idx, concrete_key in sorted(key_expansions.items(), key=lambda x: int(x[0])):
         if needs_component_expansion:
             # Get component count for this specific key
-            array = _lookup_projection_array(projections, layer_name, concrete_key, analysis_concat_layers)
+            array = _lookup_array(arrays, layer_name, concrete_key, analysis_concat_layers)
             np_array = np.asarray(array)
             if np_array.ndim != 2:
                 raise ConfigValidationError(
@@ -483,7 +483,7 @@ def _expand_field_mapping(
     field_name: str,
     ref: ActivationVisualizationFieldRef,
     layer_name: str,
-    projections: Mapping[str, np.ndarray],
+    arrays: Mapping[str, np.ndarray],
     scalars: Mapping[str, float],
     belief_states: np.ndarray | None,
     analysis_concat_layers: bool,
@@ -506,7 +506,7 @@ def _expand_field_mapping(
             )
 
         return _expand_projection_key_mapping(
-            field_name, ref, layer_name, projections, belief_states, analysis_concat_layers
+            field_name, ref, layer_name, arrays, belief_states, analysis_concat_layers
         )
 
     # Check for belief state factor patterns
@@ -556,7 +556,7 @@ def _expand_field_mapping(
     if not needs_expansion:
         return {field_name: ref}
 
-    max_components = _get_component_count(ref, layer_name, projections, belief_states, analysis_concat_layers)
+    max_components = _get_component_count(ref, layer_name, arrays, belief_states, analysis_concat_layers)
 
     if spec_type == "wildcard":
         components = list(range(max_components))

--- a/simplexity/analysis/layerwise_analysis.py
+++ b/simplexity/analysis/layerwise_analysis.py
@@ -183,13 +183,13 @@ class LayerwiseAnalysis:
         weights: jax.Array,
         belief_states: jax.Array | tuple[jax.Array, ...] | None = None,
     ) -> tuple[Mapping[str, float], Mapping[str, jax.Array]]:
-        """Analyze activations and return namespaced scalar metrics and projections."""
+        """Analyze activations and return namespaced scalar metrics and arrays."""
         if self._requires_belief_states and belief_states is None:
             raise ValueError("This analysis requires belief_states")
         scalars: dict[str, float] = {}
-        projections: dict[str, jax.Array] = {}
+        arrays: dict[str, jax.Array] = {}
         for layer_name, layer_activations in activations.items():
-            layer_scalars, layer_projections = self._analysis_fn(
+            layer_scalars, layer_arrays = self._analysis_fn(
                 layer_activations,
                 weights,
                 belief_states,
@@ -197,9 +197,9 @@ class LayerwiseAnalysis:
             )
             for key, value in layer_scalars.items():
                 scalars[f"{layer_name}_{key}"] = value
-            for key, value in layer_projections.items():
-                projections[f"{layer_name}_{key}"] = value
-        return scalars, projections
+            for key, value in layer_arrays.items():
+                arrays[f"{layer_name}_{key}"] = value
+        return scalars, arrays
 
 
 __all__ = ["LayerwiseAnalysis", "ANALYSIS_REGISTRY"]

--- a/simplexity/analysis/linear_regression.py
+++ b/simplexity/analysis/linear_regression.py
@@ -490,18 +490,18 @@ def _apply_layer_regression(
     """Apply a regression function, optionally per-factor."""
     if to_factors:
         scalars: dict[str, float] = {}
-        projections: dict[str, jax.Array] = {}
+        arrays: dict[str, jax.Array] = {}
         if not isinstance(belief_states, tuple):
             raise ValueError("belief_states must be a tuple when to_factors is True")
         for factor_idx, factor in enumerate(belief_states):
             if not isinstance(factor, jax.Array):
                 raise ValueError("Each factor in belief_states must be a jax.Array")
-            factor_scalars, factor_projections = regression_fn(layer_activations, factor, weights, **kwargs)
+            factor_scalars, factor_arrays = regression_fn(layer_activations, factor, weights, **kwargs)
             for key, value in factor_scalars.items():
                 scalars[f"factor_{factor_idx}/{key}"] = value
-            for key, value in factor_projections.items():
-                projections[f"factor_{factor_idx}/{key}"] = value
-        return scalars, projections
+            for key, value in factor_arrays.items():
+                arrays[f"factor_{factor_idx}/{key}"] = value
+        return scalars, arrays
     else:
         targets = jnp.concatenate(belief_states, axis=-1) if isinstance(belief_states, tuple) else belief_states
         return regression_fn(layer_activations, targets, weights, **kwargs)

--- a/simplexity/analysis/pca.py
+++ b/simplexity/analysis/pca.py
@@ -115,7 +115,7 @@ def layer_pca_analysis(
 
     cumulative_variance = jnp.cumsum(result["explained_variance_ratio"])
     scalars: dict[str, float] = {}
-    scalars["variance_explained"] = float(cumulative_variance[-1])
+    scalars["var_exp"] = float(cumulative_variance[-1])
 
     threshold_counts = variance_threshold_counts(
         result["all_explained_variance_ratio"],

--- a/simplexity/analysis/pca.py
+++ b/simplexity/analysis/pca.py
@@ -115,8 +115,6 @@ def layer_pca_analysis(
 
     cumulative_variance = jnp.cumsum(result["explained_variance_ratio"])
     scalars: dict[str, float] = {}
-    for idx, value in enumerate(cumulative_variance, start=1):
-        scalars[f"cumvar_{idx}"] = float(value)
     scalars["variance_explained"] = float(cumulative_variance[-1])
 
     threshold_counts = variance_threshold_counts(
@@ -127,8 +125,8 @@ def layer_pca_analysis(
         percentage = int(threshold * 100)
         scalars[f"n_components_{percentage}pct"] = float(count)
 
-    projections = {"pca": result["X_proj"]}
-    return scalars, projections
+    arrays = {"pca": result["X_proj"], "cumulative_explained_variance": cumulative_variance}
+    return scalars, arrays
 
 
 __all__ = [

--- a/simplexity/analysis/pca.py
+++ b/simplexity/analysis/pca.py
@@ -125,7 +125,7 @@ def layer_pca_analysis(
         percentage = int(threshold * 100)
         scalars[f"nc_{percentage}"] = float(count)
 
-    arrays = {"pca": result["X_proj"], "cumulative_explained_variance": cumulative_variance}
+    arrays = {"pca": result["X_proj"], "cev": cumulative_variance}
     return scalars, arrays
 
 

--- a/simplexity/generative_processes/transition_matrices.py
+++ b/simplexity/generative_processes/transition_matrices.py
@@ -95,6 +95,18 @@ def fanizza(alpha: float, lamb: float) -> jax.Array:
     return jnp.stack([da, db], axis=0)
 
 
+def leaky_rrxor(p1: float, p2: float, epsilon: float) -> jax.Array:
+    """Creates a transition matrix for the leaky RRXOR Process."""
+    assert 0 <= epsilon <= 1
+
+    transition_matrices_base = rrxor(p1, p2)
+    leak = jnp.ones((2, 5, 5))
+
+    transition_matrices = (1 - epsilon) * transition_matrices_base + (epsilon / 10) * leak
+
+    return transition_matrices
+
+
 def matching_parens(open_probs: list[float]) -> jax.Array:
     """Creates a model for generating Matching Parentheses."""
     if len(open_probs) < 1:
@@ -357,6 +369,7 @@ HMM_MATRIX_FUNCTIONS = {
     "coin": coin,
     "days_of_week": days_of_week,
     "even_ones": even_ones,
+    "leaky_rrxor": leaky_rrxor,
     "matching_parens": matching_parens,
     "mess3": mess3,
     "mr_name": mr_name,

--- a/tests/activations/test_activation_analysis.py
+++ b/tests/activations/test_activation_analysis.py
@@ -397,10 +397,10 @@ class TestPcaAnalysis:
             weights=prepared.weights,
         )
 
-        assert "variance_explained/layer_0" in scalars
+        assert "var_exp/layer_0" in scalars
         assert "nc_80/layer_0" in scalars
         assert "nc_90/layer_0" in scalars
-        assert "variance_explained/layer_1" in scalars
+        assert "var_exp/layer_1" in scalars
 
         assert "pca/layer_0" in arrays
         assert "pca/layer_1" in arrays
@@ -437,7 +437,7 @@ class TestPcaAnalysis:
             weights=prepared.weights,
         )
 
-        assert "variance_explained/layer_0" in scalars
+        assert "var_exp/layer_0" in scalars
         assert "pca/layer_0" in arrays
         assert "cev/layer_0" in arrays
 
@@ -495,7 +495,7 @@ class TestActivationTracker:
         )
 
         assert "regression/r2/layer_0" in scalars
-        assert "pca/variance_explained/layer_0" in scalars
+        assert "pca/var_exp/layer_0" in scalars
 
         assert "regression/projected/layer_0" in arrays
         assert "pca/pca/layer_0" in arrays
@@ -547,7 +547,7 @@ class TestActivationTracker:
         )
 
         assert "regression/r2/layer_0" in scalars
-        assert "pca/variance_explained/layer_0" in scalars
+        assert "pca/var_exp/layer_0" in scalars
         assert visualizations == {}
 
     def test_concatenated_layers(self, synthetic_data):
@@ -574,7 +574,7 @@ class TestActivationTracker:
         )
 
         assert "regression/r2/Lcat" in scalars
-        assert "pca/variance_explained/Lcat" in scalars
+        assert "pca/var_exp/Lcat" in scalars
 
         assert "regression/projected/Lcat" in arrays
         assert "pca/pca/Lcat" in arrays
@@ -630,8 +630,8 @@ class TestActivationTracker:
             activations=synthetic_data["activations"],
         )
 
-        assert "pca_all_tokens/variance_explained/layer_0" in scalars
-        assert "pca_last_token/variance_explained/layer_0" in scalars
+        assert "pca_all_tokens/var_exp/layer_0" in scalars
+        assert "pca_last_token/var_exp/layer_0" in scalars
         assert "regression_concat/r2/Lcat" in scalars
 
         assert "pca_all_tokens/pca/layer_0" in arrays
@@ -990,7 +990,7 @@ class TestTupleBeliefStates:
         assert "regression/r2/layer_0-F1" in scalars
 
         # PCA should still work (doesn't use belief states)
-        assert "pca/variance_explained/layer_0" in scalars
+        assert "pca/var_exp/layer_0" in scalars
 
         # Arrays should be present
         assert "regression/projected/layer_0-F0" in arrays

--- a/tests/activations/test_activation_analysis.py
+++ b/tests/activations/test_activation_analysis.py
@@ -404,14 +404,14 @@ class TestPcaAnalysis:
 
         assert "pca/layer_0" in arrays
         assert "pca/layer_1" in arrays
-        assert "cumulative_explained_variance/layer_0" in arrays
-        assert "cumulative_explained_variance/layer_1" in arrays
+        assert "cev/layer_0" in arrays
+        assert "cev/layer_1" in arrays
 
         batch_size = prepared.activations["layer_0"].shape[0]
         assert arrays["pca/layer_0"].shape == (batch_size, 3)
         assert arrays["pca/layer_1"].shape == (batch_size, 3)
-        assert arrays["cumulative_explained_variance/layer_0"].shape == (3,)
-        assert arrays["cumulative_explained_variance/layer_1"].shape == (3,)
+        assert arrays["cev/layer_0"].shape == (3,)
+        assert arrays["cev/layer_1"].shape == (3,)
 
     def test_pca_without_belief_states(self, synthetic_data):
         """Test PCA works without belief_states."""
@@ -439,7 +439,7 @@ class TestPcaAnalysis:
 
         assert "variance_explained/layer_0" in scalars
         assert "pca/layer_0" in arrays
-        assert "cumulative_explained_variance/layer_0" in arrays
+        assert "cev/layer_0" in arrays
 
     def test_pca_all_components(self, synthetic_data):
         """Test PCA with n_components=None computes all components."""

--- a/tests/activations/test_activation_analysis.py
+++ b/tests/activations/test_activation_analysis.py
@@ -231,7 +231,7 @@ class TestLinearRegressionAnalysis:
             ),
         )
 
-        scalars, projections = analysis.analyze(
+        scalars, arrays = analysis.analyze(
             activations=prepared.activations,
             belief_states=prepared.belief_states,
             weights=prepared.weights,
@@ -243,13 +243,13 @@ class TestLinearRegressionAnalysis:
         assert "layer_0_dist" in scalars
         assert "layer_1_r2" in scalars
 
-        assert "layer_0_projected" in projections
-        assert "layer_1_projected" in projections
+        assert "layer_0_projected" in arrays
+        assert "layer_1_projected" in arrays
 
         assert prepared.belief_states is not None
         assert isinstance(prepared.belief_states, jax.Array)
-        assert projections["layer_0_projected"].shape == prepared.belief_states.shape
-        assert projections["layer_1_projected"].shape == prepared.belief_states.shape
+        assert arrays["layer_0_projected"].shape == prepared.belief_states.shape
+        assert arrays["layer_1_projected"].shape == prepared.belief_states.shape
 
     def test_requires_belief_states(self, synthetic_data):
         """Test that analysis raises error without belief_states."""
@@ -292,14 +292,14 @@ class TestLinearRegressionAnalysis:
             ),
         )
 
-        scalars, projections = analysis.analyze(
+        scalars, arrays = analysis.analyze(
             activations=prepared.activations,
             belief_states=prepared.belief_states,
             weights=prepared.weights,
         )
 
         assert "layer_0_r2" in scalars
-        assert "layer_0_projected" in projections
+        assert "layer_0_projected" in arrays
 
 
 class TestLinearRegressionSVDAnalysis:
@@ -321,7 +321,7 @@ class TestLinearRegressionSVDAnalysis:
             ),
         )
 
-        scalars, projections = analysis.analyze(
+        scalars, arrays = analysis.analyze(
             activations=prepared.activations,
             belief_states=prepared.belief_states,
             weights=prepared.weights,
@@ -335,13 +335,13 @@ class TestLinearRegressionSVDAnalysis:
         assert "layer_1_r2" in scalars
         assert "layer_1_best_rcond" in scalars
 
-        assert "layer_0_projected" in projections
-        assert "layer_1_projected" in projections
+        assert "layer_0_projected" in arrays
+        assert "layer_1_projected" in arrays
 
         assert prepared.belief_states is not None
         assert isinstance(prepared.belief_states, jax.Array)
-        assert projections["layer_0_projected"].shape == prepared.belief_states.shape
-        assert projections["layer_1_projected"].shape == prepared.belief_states.shape
+        assert arrays["layer_0_projected"].shape == prepared.belief_states.shape
+        assert arrays["layer_1_projected"].shape == prepared.belief_states.shape
 
         # Check that best_rcond is one of the provided values
         assert scalars["layer_0_best_rcond"] in [1e-15, 1e-10, 1e-8]
@@ -391,27 +391,27 @@ class TestPcaAnalysis:
             ),
         )
 
-        scalars, projections = analysis.analyze(
+        scalars, arrays = analysis.analyze(
             activations=prepared.activations,
             belief_states=prepared.belief_states,
             weights=prepared.weights,
         )
 
-        assert "layer_0_cumvar_1" in scalars
-        assert "layer_0_cumvar_2" in scalars
-        assert "layer_0_cumvar_3" in scalars
-        assert scalars["layer_0_cumvar_1"] <= scalars["layer_0_cumvar_2"]
-        assert scalars["layer_0_cumvar_2"] <= scalars["layer_0_cumvar_3"]
+        assert "layer_0_variance_explained" in scalars
         assert "layer_0_n_components_80pct" in scalars
         assert "layer_0_n_components_90pct" in scalars
-        assert "layer_1_cumvar_1" in scalars
+        assert "layer_1_variance_explained" in scalars
 
-        assert "layer_0_pca" in projections
-        assert "layer_1_pca" in projections
+        assert "layer_0_pca" in arrays
+        assert "layer_1_pca" in arrays
+        assert "layer_0_cumulative_explained_variance" in arrays
+        assert "layer_1_cumulative_explained_variance" in arrays
 
         batch_size = prepared.activations["layer_0"].shape[0]
-        assert projections["layer_0_pca"].shape == (batch_size, 3)
-        assert projections["layer_1_pca"].shape == (batch_size, 3)
+        assert arrays["layer_0_pca"].shape == (batch_size, 3)
+        assert arrays["layer_1_pca"].shape == (batch_size, 3)
+        assert arrays["layer_0_cumulative_explained_variance"].shape == (3,)
+        assert arrays["layer_1_cumulative_explained_variance"].shape == (3,)
 
     def test_pca_without_belief_states(self, synthetic_data):
         """Test PCA works without belief_states."""
@@ -431,15 +431,15 @@ class TestPcaAnalysis:
 
         prepared.belief_states = None
 
-        scalars, projections = analysis.analyze(
+        scalars, arrays = analysis.analyze(
             activations=prepared.activations,
             belief_states=prepared.belief_states,
             weights=prepared.weights,
         )
 
-        assert "layer_0_cumvar_1" in scalars
-        assert "layer_0_cumvar_2" in scalars
-        assert "layer_0_pca" in projections
+        assert "layer_0_variance_explained" in scalars
+        assert "layer_0_pca" in arrays
+        assert "layer_0_cumulative_explained_variance" in arrays
 
     def test_pca_all_components(self, synthetic_data):
         """Test PCA with n_components=None computes all components."""
@@ -457,7 +457,7 @@ class TestPcaAnalysis:
             ),
         )
 
-        _, projections = analysis.analyze(
+        _, arrays = analysis.analyze(
             activations=prepared.activations,
             belief_states=prepared.belief_states,
             weights=prepared.weights,
@@ -465,7 +465,7 @@ class TestPcaAnalysis:
 
         batch_size = prepared.activations["layer_0"].shape[0]
         d_layer0 = synthetic_data["d_layer0"]
-        assert projections["layer_0_pca"].shape == (batch_size, min(batch_size, d_layer0))
+        assert arrays["layer_0_pca"].shape == (batch_size, min(batch_size, d_layer0))
 
 
 class TestActivationTracker:
@@ -487,7 +487,7 @@ class TestActivationTracker:
             }
         )
 
-        scalars, projections, visualizations = tracker.analyze(
+        scalars, arrays, visualizations = tracker.analyze(
             inputs=synthetic_data["inputs"],
             beliefs=synthetic_data["beliefs"],
             probs=synthetic_data["probs"],
@@ -497,8 +497,8 @@ class TestActivationTracker:
         assert "regression/layer_0_r2" in scalars
         assert "pca/layer_0_variance_explained" in scalars
 
-        assert "regression/layer_0_projected" in projections
-        assert "pca/layer_0_pca" in projections
+        assert "regression/layer_0_projected" in arrays
+        assert "pca/layer_0_pca" in arrays
         assert visualizations == {}
 
     def test_all_tokens_mode(self, synthetic_data):
@@ -512,7 +512,7 @@ class TestActivationTracker:
             }
         )
 
-        scalars, projections, visualizations = tracker.analyze(
+        scalars, arrays, visualizations = tracker.analyze(
             inputs=synthetic_data["inputs"],
             beliefs=synthetic_data["beliefs"],
             probs=synthetic_data["probs"],
@@ -520,7 +520,7 @@ class TestActivationTracker:
         )
 
         assert "regression/layer_0_r2" in scalars
-        assert "regression/layer_0_projected" in projections
+        assert "regression/layer_0_projected" in arrays
         assert visualizations == {}
 
     def test_mixed_requirements(self, synthetic_data):
@@ -566,7 +566,7 @@ class TestActivationTracker:
             }
         )
 
-        scalars, projections, visualizations = tracker.analyze(
+        scalars, arrays, visualizations = tracker.analyze(
             inputs=synthetic_data["inputs"],
             beliefs=synthetic_data["beliefs"],
             probs=synthetic_data["probs"],
@@ -576,8 +576,8 @@ class TestActivationTracker:
         assert "regression/concatenated_r2" in scalars
         assert "pca/concatenated_variance_explained" in scalars
 
-        assert "regression/concatenated_projected" in projections
-        assert "pca/concatenated_pca" in projections
+        assert "regression/concatenated_projected" in arrays
+        assert "pca/concatenated_pca" in arrays
         assert visualizations == {}
 
     def test_uniform_weights(self, synthetic_data):
@@ -623,7 +623,7 @@ class TestActivationTracker:
             }
         )
 
-        scalars, projections, visualizations = tracker.analyze(
+        scalars, arrays, visualizations = tracker.analyze(
             inputs=synthetic_data["inputs"],
             beliefs=synthetic_data["beliefs"],
             probs=synthetic_data["probs"],
@@ -634,9 +634,9 @@ class TestActivationTracker:
         assert "pca_last_token/layer_0_variance_explained" in scalars
         assert "regression_concat/concatenated_r2" in scalars
 
-        assert "pca_all_tokens/layer_0_pca" in projections
-        assert "pca_last_token/layer_0_pca" in projections
-        assert "regression_concat/concatenated_projected" in projections
+        assert "pca_all_tokens/layer_0_pca" in arrays
+        assert "pca_last_token/layer_0_pca" in arrays
+        assert "regression_concat/concatenated_projected" in arrays
         assert visualizations == {}
 
     def test_tracker_accepts_torch_inputs(self, synthetic_data):
@@ -663,7 +663,7 @@ class TestActivationTracker:
             name: torch.tensor(np.asarray(layer)) for name, layer in synthetic_data["activations"].items()
         }
 
-        scalars, projections, visualizations = tracker.analyze(
+        scalars, arrays, visualizations = tracker.analyze(
             inputs=torch_inputs,
             beliefs=torch_beliefs,
             probs=torch_probs,
@@ -671,7 +671,7 @@ class TestActivationTracker:
         )
 
         assert "regression/layer_0_r2" in scalars
-        assert "pca/layer_0_pca" in projections
+        assert "pca/layer_0_pca" in arrays
         assert visualizations == {}
 
     def test_tracker_builds_visualizations(self, synthetic_data, monkeypatch):
@@ -899,7 +899,7 @@ class TestTupleBeliefStates:
             ),
         )
 
-        scalars, projections = analysis.analyze(
+        scalars, arrays = analysis.analyze(
             activations=prepared.activations,
             belief_states=prepared.belief_states,
             weights=prepared.weights,
@@ -919,16 +919,16 @@ class TestTupleBeliefStates:
         assert "layer_1_factor_0/r2" in scalars
         assert "layer_1_factor_1/r2" in scalars
 
-        # Should have separate projections for each factor
-        assert "layer_0_factor_0/projected" in projections
-        assert "layer_0_factor_1/projected" in projections
-        assert "layer_1_factor_0/projected" in projections
-        assert "layer_1_factor_1/projected" in projections
+        # Should have separate arrays for each factor
+        assert "layer_0_factor_0/projected" in arrays
+        assert "layer_0_factor_1/projected" in arrays
+        assert "layer_1_factor_0/projected" in arrays
+        assert "layer_1_factor_1/projected" in arrays
 
         # Check projection shapes
         batch_size = factored_belief_data["batch_size"]
-        assert projections["layer_0_factor_0/projected"].shape == (batch_size, factored_belief_data["factor_0_dim"])
-        assert projections["layer_0_factor_1/projected"].shape == (batch_size, factored_belief_data["factor_1_dim"])
+        assert arrays["layer_0_factor_0/projected"].shape == (batch_size, factored_belief_data["factor_0_dim"])
+        assert arrays["layer_0_factor_1/projected"].shape == (batch_size, factored_belief_data["factor_1_dim"])
 
     def test_linear_regression_svd_with_multiple_factors(self, factored_belief_data):
         """LinearRegressionSVDAnalysis with multi-factor tuple should regress to each factor separately."""
@@ -946,7 +946,7 @@ class TestTupleBeliefStates:
             ),
         )
 
-        scalars, projections = analysis.analyze(
+        scalars, arrays = analysis.analyze(
             activations=prepared.activations,
             belief_states=prepared.belief_states,
             weights=prepared.weights,
@@ -958,9 +958,9 @@ class TestTupleBeliefStates:
         assert "layer_0_factor_0/best_rcond" in scalars
         assert "layer_0_factor_1/best_rcond" in scalars
 
-        # Should have separate projections for each factor
-        assert "layer_0_factor_0/projected" in projections
-        assert "layer_0_factor_1/projected" in projections
+        # Should have separate arrays for each factor
+        assert "layer_0_factor_0/projected" in arrays
+        assert "layer_0_factor_1/projected" in arrays
 
     def test_tracker_with_factored_beliefs(self, factored_belief_data):
         """ActivationTracker should work with tuple belief states."""
@@ -978,7 +978,7 @@ class TestTupleBeliefStates:
             }
         )
 
-        scalars, projections, _ = tracker.analyze(
+        scalars, arrays, _ = tracker.analyze(
             inputs=factored_belief_data["inputs"],
             beliefs=factored_belief_data["factored_beliefs"],
             probs=factored_belief_data["probs"],
@@ -992,10 +992,10 @@ class TestTupleBeliefStates:
         # PCA should still work (doesn't use belief states)
         assert "pca/layer_0_variance_explained" in scalars
 
-        # Projections should be present
-        assert "regression/layer_0_factor_0/projected" in projections
-        assert "regression/layer_0_factor_1/projected" in projections
-        assert "pca/layer_0_pca" in projections
+        # Arrays should be present
+        assert "regression/layer_0_factor_0/projected" in arrays
+        assert "regression/layer_0_factor_1/projected" in arrays
+        assert "pca/layer_0_pca" in arrays
 
     def test_single_factor_tuple(self, synthetic_data):
         """Test with a single-factor tuple (edge case)."""
@@ -1036,7 +1036,7 @@ class TestTupleBeliefStates:
             ),
         )
 
-        scalars, projections = analysis.analyze(
+        scalars, arrays = analysis.analyze(
             activations=prepared.activations,
             belief_states=prepared.belief_states,
             weights=prepared.weights,
@@ -1045,11 +1045,11 @@ class TestTupleBeliefStates:
         # Should have simple keys without "factor_" prefix
         assert "layer_0_r2" in scalars
         assert "layer_0_rmse" in scalars
-        assert "layer_0_projected" in projections
+        assert "layer_0_projected" in arrays
 
         # Should NOT have factor keys
         assert "layer_0_factor_0/r2" not in scalars
-        assert "layer_0_factor_0/projected" not in projections
+        assert "layer_0_factor_0/projected" not in arrays
 
     def test_linear_regression_concat_belief_states(self, factored_belief_data):
         """LinearRegressionAnalysis with concat_belief_states=True should return both factor and concat results."""
@@ -1067,7 +1067,7 @@ class TestTupleBeliefStates:
             ),
         )
 
-        scalars, projections = analysis.analyze(
+        scalars, arrays = analysis.analyze(
             activations=prepared.activations,
             belief_states=prepared.belief_states,
             weights=prepared.weights,
@@ -1076,18 +1076,18 @@ class TestTupleBeliefStates:
         # Should have per-factor results
         assert "layer_0_factor_0/r2" in scalars
         assert "layer_0_factor_1/r2" in scalars
-        assert "layer_0_factor_0/projected" in projections
-        assert "layer_0_factor_1/projected" in projections
+        assert "layer_0_factor_0/projected" in arrays
+        assert "layer_0_factor_1/projected" in arrays
 
         # Should ALSO have concatenated results
         assert "layer_0_concat/r2" in scalars
         assert "layer_0_concat/rmse" in scalars
-        assert "layer_0_concat/projected" in projections
+        assert "layer_0_concat/projected" in arrays
 
         # Check concatenated projection shape (should be sum of factor dimensions)
         batch_size = factored_belief_data["batch_size"]
         total_dim = factored_belief_data["factor_0_dim"] + factored_belief_data["factor_1_dim"]
-        assert projections["layer_0_concat/projected"].shape == (batch_size, total_dim)
+        assert arrays["layer_0_concat/projected"].shape == (batch_size, total_dim)
 
     def test_three_factor_tuple(self, factored_belief_data):
         """Test with three factors to ensure generalization."""
@@ -1139,7 +1139,7 @@ class TestTupleBeliefStates:
             compute_subspace_orthogonality=True,
         )
 
-        scalars, projections = analysis.analyze(
+        scalars, arrays = analysis.analyze(
             activations=prepared.activations,
             belief_states=prepared.belief_states,
             weights=prepared.weights,

--- a/tests/activations/test_activation_tracker.py
+++ b/tests/activations/test_activation_tracker.py
@@ -246,14 +246,14 @@ class TestActivationTrackerVisualizationHandling:
         tracker = ActivationTracker(
             analyses={"pca": PcaAnalysis(n_components=1, last_token_only=False, concat_layers=False)},
         )
-        scalars, projections, visualizations = tracker.analyze(
+        scalars, arrays, visualizations = tracker.analyze(
             inputs=synthetic_data["inputs"],
             beliefs=synthetic_data["beliefs"],
             probs=synthetic_data["probs"],
             activations=synthetic_data["activations"],
         )
         assert len(scalars) > 0
-        assert len(projections) > 0
+        assert len(arrays) > 0
         assert len(visualizations) == 0
 
     def test_analyze_records_scalar_history(self, synthetic_data):
@@ -307,7 +307,7 @@ class TestActivationTrackerVisualizationHandling:
             analyses={"pca": PcaAnalysis(n_components=1, last_token_only=False, concat_layers=False)},
             visualizations={"pca": [viz_cfg]},
         )
-        scalars, projections, visualizations = tracker.analyze(
+        scalars, arrays, visualizations = tracker.analyze(
             inputs=synthetic_data["inputs"],
             beliefs=beliefs_tuple,
             probs=synthetic_data["probs"],
@@ -337,7 +337,7 @@ class TestActivationTrackerVisualizationHandling:
             visualizations={"pca": [viz_cfg]},
         )
         # PCA doesn't require beliefs, so this should work
-        scalars, projections, visualizations = tracker.analyze(
+        scalars, arrays, visualizations = tracker.analyze(
             inputs=synthetic_data["inputs"],
             beliefs=synthetic_data["beliefs"],
             probs=synthetic_data["probs"],

--- a/tests/activations/test_activation_visualizations.py
+++ b/tests/activations/test_activation_visualizations.py
@@ -198,7 +198,7 @@ class TestBuildVisualizationPayloads:
 
     def test_builds_payload_with_projections(self, basic_metadata, basic_viz_config):
         """Test building a payload with projection data."""
-        projections = {"layer_0_pca": np.array([[1.0, 2.0], [3.0, 4.0]])}
+        arrays = {"layer_0_pca": np.array([[1.0, 2.0], [3.0, 4.0]])}
         payloads = build_visualization_payloads(
             analysis_name="test",
             viz_cfgs=[basic_viz_config],
@@ -206,7 +206,7 @@ class TestBuildVisualizationPayloads:
             prepared_metadata=basic_metadata,
             weights=np.array([0.5, 0.5]),
             belief_states=None,
-            projections=projections,
+            arrays=arrays,
             scalars={},
             scalar_history={},
             scalar_history_step=None,
@@ -244,7 +244,7 @@ class TestBuildVisualizationPayloads:
             prepared_metadata=basic_metadata,
             weights=np.array([0.5, 0.5]),
             belief_states=belief_states,
-            projections={},
+            arrays={},
             scalars={},
             scalar_history={},
             scalar_history_step=None,
@@ -278,7 +278,7 @@ class TestBuildVisualizationPayloads:
                 }
             ),
         ]
-        projections = {"layer_0_pca": np.array([[1.0, 2.0], [3.0, 4.0]])}
+        arrays = {"layer_0_pca": np.array([[1.0, 2.0], [3.0, 4.0]])}
         payloads = build_visualization_payloads(
             analysis_name="test",
             viz_cfgs=configs,
@@ -286,7 +286,7 @@ class TestBuildVisualizationPayloads:
             prepared_metadata=basic_metadata,
             weights=np.array([0.5, 0.5]),
             belief_states=None,
-            projections=projections,
+            arrays=arrays,
             scalars={},
             scalar_history={},
             scalar_history_step=None,

--- a/tests/activations/test_dataframe_integration.py
+++ b/tests/activations/test_dataframe_integration.py
@@ -33,7 +33,7 @@ class TestProjectionDataframeIntegration:
         factor_0_data = np.array([[0.1, 0.8, 0.1], [0.2, 0.7, 0.1], [0.3, 0.6, 0.1]])
         factor_1_data = np.array([[0.5, 0.5], [0.4, 0.6], [0.3, 0.7]])
 
-        projections = {
+        arrays = {
             "layer_0_factor_0/projected": factor_0_data,
             "layer_0_factor_1/projected": factor_1_data,
         }
@@ -65,7 +65,7 @@ class TestProjectionDataframeIntegration:
         df = _build_dataframe_for_mappings(
             mappings=mappings,
             metadata_columns=metadata_columns,
-            projections=projections,
+            arrays=arrays,
             scalars={},
             belief_states=None,
             analysis_concat_layers=False,
@@ -123,7 +123,7 @@ class TestProjectionDataframeIntegration:
         factor_0_data = np.array([[0.1, 0.8, 0.1], [0.2, 0.7, 0.1]])  # 3 components
         factor_1_data = np.array([[0.5, 0.5], [0.4, 0.6]])  # 2 components
 
-        projections = {
+        arrays = {
             "layer_0_factor_0/projected": factor_0_data,
             "layer_0_factor_1/projected": factor_1_data,
         }
@@ -148,7 +148,7 @@ class TestProjectionDataframeIntegration:
             _build_dataframe_for_mappings(
                 mappings=mappings,
                 metadata_columns=metadata_columns,
-                projections=projections,
+                arrays=arrays,
                 scalars={},
                 belief_states=None,
                 analysis_concat_layers=False,
@@ -173,7 +173,7 @@ class TestProjectionDataframeIntegration:
         noise = np.random.default_rng(42).standard_normal((n_samples, n_factors, n_states)) * 0.01
         projected_values = belief_states + noise
 
-        projections = {
+        arrays = {
             "layer_0_factor_0/projected": projected_values[:, 0, :],
             "layer_0_factor_1/projected": projected_values[:, 1, :],
         }
@@ -216,7 +216,7 @@ class TestProjectionDataframeIntegration:
         df = _build_dataframe(
             viz_cfg=config,
             metadata_columns=metadata_columns,
-            projections=projections,
+            arrays=arrays,
             scalars={},
             scalar_history={},
             scalar_history_step=None,
@@ -237,7 +237,7 @@ class TestProjectionDataframeIntegration:
         n_states = 3
 
         belief_states = np.random.rand(n_samples, n_factors, n_states)
-        projections = {
+        arrays = {
             f"layer_{layer_idx}_factor_{factor_idx}/projected": np.random.rand(n_samples, n_states)
             for layer_idx in range(n_layers)
             for factor_idx in range(n_factors)
@@ -279,7 +279,7 @@ class TestProjectionDataframeIntegration:
         df = _build_dataframe(
             viz_cfg=config,
             metadata_columns=metadata_columns,
-            projections=projections,
+            arrays=arrays,
             scalars={},
             scalar_history={},
             scalar_history_step=None,
@@ -301,7 +301,7 @@ class TestProjectionDataframeIntegration:
         nf_df = _build_dataframe_for_mappings(
             mappings={"prob_0": ActivationVisualizationFieldRef(source="projections", key="projected", component=0)},
             metadata_columns=metadata,
-            projections={"layer_0_projected": projection_data},
+            arrays={"layer_0_projected": projection_data},
             scalars={},
             belief_states=None,
             analysis_concat_layers=False,
@@ -314,7 +314,7 @@ class TestProjectionDataframeIntegration:
                 )
             },
             metadata_columns=metadata,
-            projections={"layer_0_factor_0/projected": projection_data},
+            arrays={"layer_0_factor_0/projected": projection_data},
             scalars={},
             belief_states=None,
             analysis_concat_layers=False,
@@ -339,11 +339,11 @@ class TestProjectionDataframeIntegration:
         beliefs_softmax = beliefs_softmax / beliefs_softmax.sum(axis=2, keepdims=True)
 
         belief_states = tuple(jnp.array(beliefs_softmax[:, f, :]) for f in range(n_factors))
-        scalars, projections = layer_linear_regression(
+        scalars, arrays = layer_linear_regression(
             jnp.array(ds), jnp.ones(n_samples) / n_samples, belief_states, use_svd=True
         )
 
         for f in range(n_factors):
             assert scalars[f"factor_{f}/r2"] > 0.8, f"Factor {f} R² too low"
-            diff = np.abs(np.asarray(projections[f"factor_{f}/projected"]) - np.asarray(belief_states[f]))
+            diff = np.abs(np.asarray(arrays[f"factor_{f}/projected"]) - np.asarray(belief_states[f]))
             assert diff.max() < 0.2, f"Factor {f} projections differ too much from beliefs"

--- a/tests/activations/test_field_expansion.py
+++ b/tests/activations/test_field_expansion.py
@@ -568,10 +568,10 @@ class TestKeyPatternExpansion:
 
     def test_expand_projection_key_pattern_no_matches_raises(self):
         """Test that _expand_projection_key_pattern raises an error when no keys match."""
-        projections = {"layer_0_pca": np.random.randn(10, 3)}
+        arrays = {"layer_0_pca": np.random.randn(10, 3)}
 
-        with pytest.raises(ConfigValidationError, match="No projection keys found"):
-            _expand_projection_key_pattern("factor_*/projected", "layer_0", projections, False)
+        with pytest.raises(ConfigValidationError, match="No array keys found"):
+            _expand_projection_key_pattern("factor_*/projected", "layer_0", arrays, False)
 
     def test_field_mapping_with_key_pattern(self):
         """Test that field mappings with key patterns are expanded correctly."""

--- a/tests/activations/test_scalar_history.py
+++ b/tests/activations/test_scalar_history.py
@@ -275,7 +275,7 @@ class TestScalarHistoryVisualizations:
             _build_dataframe(
                 viz_cfg,
                 self._metadata(),
-                projections={},
+                arrays={},
                 scalars={"analysis/layer_0_rmse": 0.1},
                 scalar_history={},
                 scalar_history_step=None,
@@ -290,7 +290,7 @@ class TestScalarHistoryVisualizations:
         df = _build_dataframe(
             viz_cfg,
             self._metadata(),
-            projections={},
+            arrays={},
             scalars={"analysis/layer_0_rmse": 0.42},
             scalar_history={},
             scalar_history_step=7,
@@ -326,7 +326,7 @@ class TestScalarHistoryVisualizations:
         df = _build_dataframe(
             viz_cfg,
             self._metadata(),
-            projections={},
+            arrays={},
             scalars=scalars,
             scalar_history={},
             scalar_history_step=11,
@@ -366,7 +366,7 @@ class TestScalarHistoryVisualizations:
         df = _build_dataframe(
             viz_cfg,
             self._metadata(),
-            projections={},
+            arrays={},
             scalars=scalars,
             scalar_history={},
             scalar_history_step=3,
@@ -395,7 +395,7 @@ class TestScalarHistoryVisualizations:
             _build_dataframe(
                 viz_cfg,
                 self._metadata(),
-                projections={},
+                arrays={},
                 scalars={"analysis/other_metric": 0.1},
                 scalar_history={},
                 scalar_history_step=0,

--- a/tests/activations/test_visualization_modules.py
+++ b/tests/activations/test_visualization_modules.py
@@ -19,7 +19,7 @@ from simplexity.activations.visualization.dataframe_builders import (
     _scalar_series_metadata,
 )
 from simplexity.activations.visualization.field_resolution import (
-    _lookup_projection_array,
+    _lookup_array,
     _lookup_scalar_value,
     _maybe_component,
     _resolve_belief_states,
@@ -56,27 +56,27 @@ from simplexity.exceptions import ConfigValidationError
 class TestFieldResolution:
     """Tests for field_resolution.py functions."""
 
-    def test_lookup_projection_array_none_key(self):
+    def test_lookup_array_none_key(self):
         """Test that None key raises error."""
         with pytest.raises(ConfigValidationError, match="must supply a `key` value"):
-            _lookup_projection_array({}, "layer_0", None, False)
+            _lookup_array({}, "layer_0", None, False)
 
-    def test_lookup_projection_array_not_found(self):
-        """Test that missing projection raises error."""
-        projections = {"layer_0_other": np.array([1, 2, 3])}
+    def test_lookup_array_not_found(self):
+        """Test that missing array raises error."""
+        arrays = {"layer_0_other": np.array([1, 2, 3])}
         with pytest.raises(ConfigValidationError, match="not available for layer"):
-            _lookup_projection_array(projections, "layer_0", "missing", False)
+            _lookup_array(arrays, "layer_0", "missing", False)
 
-    def test_lookup_projection_array_concat_layers_exact_match(self):
+    def test_lookup_array_concat_layers_exact_match(self):
         """Test exact key match with concat_layers."""
-        projections = {"my_key": np.array([1, 2, 3])}
-        result = _lookup_projection_array(projections, "layer_0", "my_key", True)
+        arrays = {"my_key": np.array([1, 2, 3])}
+        result = _lookup_array(arrays, "layer_0", "my_key", True)
         np.testing.assert_array_equal(result, [1, 2, 3])
 
-    def test_lookup_projection_array_concat_layers_suffix_match(self):
+    def test_lookup_array_concat_layers_suffix_match(self):
         """Test suffix match with concat_layers."""
-        projections = {"prefix_my_key": np.array([4, 5, 6])}
-        result = _lookup_projection_array(projections, "layer_0", "my_key", True)
+        arrays = {"prefix_my_key": np.array([4, 5, 6])}
+        result = _lookup_array(arrays, "layer_0", "my_key", True)
         np.testing.assert_array_equal(result, [4, 5, 6])
 
     def test_lookup_scalar_value_concat_layers_exact(self):
@@ -276,7 +276,7 @@ class TestPatternExpansion:
     def test_expand_projection_key_pattern_no_matches(self):
         """Test that no matching projections raises error."""
         projections = {"layer_0_other": np.ones((3, 4))}
-        with pytest.raises(ConfigValidationError, match="No projection keys found"):
+        with pytest.raises(ConfigValidationError, match="No array keys found"):
             _expand_projection_key_pattern("key_*", "layer_0", projections, False)
 
     def test_expand_belief_factor_mapping_wrong_dim(self):

--- a/tests/analysis/test_layerwise_analysis.py
+++ b/tests/analysis/test_layerwise_analysis.py
@@ -27,19 +27,19 @@ def analysis_inputs() -> tuple[dict[str, jnp.ndarray], jnp.ndarray, jnp.ndarray]
 
 
 def test_layerwise_analysis_linear_regression_namespacing(analysis_inputs) -> None:
-    """Metrics and projections should be namespace-qualified per layer."""
+    """Metrics and arrays should be namespace-qualified per layer."""
 
     activations, weights, belief_states = analysis_inputs
     analysis = LayerwiseAnalysis("linear_regression", last_token_only=True)
 
-    scalars, projections = analysis.analyze(
+    scalars, arrays = analysis.analyze(
         activations=activations,
         weights=weights,
         belief_states=belief_states,
     )
 
     assert set(scalars) >= {"layer_a_r2", "layer_b_r2"}
-    assert set(projections) == {
+    assert set(arrays) == {
         "layer_a_projected",
         "layer_b_projected",
         "layer_a_coeffs",
@@ -84,14 +84,15 @@ def test_pca_analysis_does_not_require_beliefs(analysis_inputs) -> None:
         "pca",
         analysis_kwargs={"n_components": 2, "variance_thresholds": (0.5,)},
     )
-    scalars, projections = analysis.analyze(
+    scalars, arrays = analysis.analyze(
         activations=activations,
         weights=weights,
         belief_states=None,
     )
-    assert "layer_a_cumvar_1" in scalars
+    assert "layer_a_variance_explained" in scalars
     assert "layer_a_n_components_50pct" in scalars
-    assert "layer_a_pca" in projections
+    assert "layer_a_pca" in arrays
+    assert "layer_a_cumulative_explained_variance" in arrays
 
 
 def test_invalid_pca_kwargs() -> None:

--- a/tests/analysis/test_layerwise_analysis.py
+++ b/tests/analysis/test_layerwise_analysis.py
@@ -92,7 +92,7 @@ def test_pca_analysis_does_not_require_beliefs(analysis_inputs) -> None:
     assert "variance_explained/layer_a" in scalars
     assert "nc_50/layer_a" in scalars
     assert "pca/layer_a" in arrays
-    assert "cumulative_explained_variance/layer_a" in arrays
+    assert "cev/layer_a" in arrays
 
 
 def test_invalid_pca_kwargs() -> None:

--- a/tests/analysis/test_layerwise_analysis.py
+++ b/tests/analysis/test_layerwise_analysis.py
@@ -89,7 +89,7 @@ def test_pca_analysis_does_not_require_beliefs(analysis_inputs) -> None:
         weights=weights,
         belief_states=None,
     )
-    assert "variance_explained/layer_a" in scalars
+    assert "var_exp/layer_a" in scalars
     assert "nc_50/layer_a" in scalars
     assert "pca/layer_a" in arrays
     assert "cev/layer_a" in arrays

--- a/tests/analysis/test_pca.py
+++ b/tests/analysis/test_pca.py
@@ -28,20 +28,22 @@ def test_variance_threshold_counts_increasing() -> None:
 
 
 def test_layer_pca_analysis_metrics() -> None:
-    """Layer PCA wrapper returns metrics and projections without beliefs."""
+    """Layer PCA wrapper returns metrics and arrays without beliefs."""
     activations = jnp.array([[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]])
     weights = jnp.ones(3) / 3.0
-    scalars, projections = layer_pca_analysis(
+    scalars, arrays = layer_pca_analysis(
         activations,
         weights,
         belief_states=None,
         n_components=2,
         variance_thresholds=(0.5,),
     )
-    assert "cumvar_1" in scalars
     assert "n_components_50pct" in scalars
-    assert "pca" in projections
-    assert projections["pca"].shape == (3, 2)
+    assert "variance_explained" in scalars
+    assert "pca" in arrays
+    assert arrays["pca"].shape == (3, 2)
+    assert "cumulative_explained_variance" in arrays
+    assert arrays["cumulative_explained_variance"].shape == (2,)
 
 
 def test_compute_weighted_pca_rejects_bad_weights_shape() -> None:
@@ -94,14 +96,14 @@ def test_layer_pca_analysis_zero_variance_threshold_reporting() -> None:
     """Layer PCA should propagate fallback counts into the scalar outputs."""
     activations = jnp.ones((4, 3))
     weights = jnp.ones(4) / 4.0
-    scalars, projections = layer_pca_analysis(
+    scalars, arrays = layer_pca_analysis(
         activations,
         weights,
         belief_states=None,
         variance_thresholds=(0.5,),
     )
     assert scalars["n_components_50pct"] == 3.0
-    assert projections["pca"].shape == (4, 3)
+    assert arrays["pca"].shape == (4, 3)
 
 
 def test_compute_weighted_pca_requires_two_dimensional_inputs() -> None:

--- a/tests/analysis/test_pca.py
+++ b/tests/analysis/test_pca.py
@@ -42,8 +42,8 @@ def test_layer_pca_analysis_metrics() -> None:
     assert "variance_explained" in scalars
     assert "pca" in arrays
     assert arrays["pca"].shape == (3, 2)
-    assert "cumulative_explained_variance" in arrays
-    assert arrays["cumulative_explained_variance"].shape == (2,)
+    assert "cev" in arrays
+    assert arrays["cev"].shape == (2,)
 
 
 def test_compute_weighted_pca_rejects_bad_weights_shape() -> None:

--- a/tests/analysis/test_pca.py
+++ b/tests/analysis/test_pca.py
@@ -39,7 +39,7 @@ def test_layer_pca_analysis_metrics() -> None:
         variance_thresholds=(0.5,),
     )
     assert "nc_50" in scalars
-    assert "variance_explained" in scalars
+    assert "var_exp" in scalars
     assert "pca" in arrays
     assert arrays["pca"].shape == (3, 2)
     assert "cev" in arrays

--- a/tests/end_to_end/configs/activation_tracker/with_visuals.yaml
+++ b/tests/end_to_end/configs/activation_tracker/with_visuals.yaml
@@ -41,29 +41,6 @@ instance:
           guides:
             title: "PCA Projection (3D)"
             subtitle: "All tokens, weighted by prefix probability"
-        - name: cumulative_explained_variance # <- NEW VISUALIZATION
-          controls:
-            dropdown: layer
-            accumulate_steps: true
-            cumulative: false
-          data_mapping:
-            scalar_series:
-              key_template: "{layer}_cumvar_{index}"
-              index_field: n_components
-              value_field: cumulative_explained_variance
-          backend: altair
-          layer:
-            geometry:
-              type: line
-              props: {}
-            aesthetics:
-              x: {field: n_components, type: quantitative, title: "Number of PCA Components"}
-              y: {field: cumulative_explained_variance, type: quantitative, title: "Cumulative Explained Variance"}
-              color: {field: step, type: nominal, title: Step}
-          size: {width: 600, height: 400}
-          guides:
-            title: "Cumulative Explained Variance by PCA Components"
-            subtitle: "All tokens, weighted by probability"
 
     regression: # <- THIS RETURNS SCALARS AND PROJECTIONS
       instance:

--- a/tests/structured_configs/test_activation_tracker_config.py
+++ b/tests/structured_configs/test_activation_tracker_config.py
@@ -250,14 +250,14 @@ def test_instantiate_activation_tracker_builds_analysis_objects(tracker_cfg: Dic
     probs = jnp.ones((1, 2), dtype=jnp.float32) * 0.5
     activations = {"layer": jnp.ones((1, 2, 4), dtype=jnp.float32)}
 
-    scalars, projections, visualizations = tracker.analyze(
+    scalars, arrays, visualizations = tracker.analyze(
         inputs=inputs,
         beliefs=beliefs,
         probs=probs,
         activations=activations,
     )
-    assert "pca_custom/layer_cumvar_1" in scalars
-    assert any(key.startswith("linear/") for key in projections)
+    assert "pca_custom/layer_variance_explained" in scalars
+    assert any(key.startswith("linear/") for key in arrays)
     assert visualizations == {}
 
 

--- a/tests/structured_configs/test_activation_tracker_config.py
+++ b/tests/structured_configs/test_activation_tracker_config.py
@@ -256,7 +256,7 @@ def test_instantiate_activation_tracker_builds_analysis_objects(tracker_cfg: Dic
         probs=probs,
         activations=activations,
     )
-    assert "pca_custom/variance_explained/layer" in scalars
+    assert "pca_custom/var_exp/layer" in scalars
     assert any(key.startswith("linear/") for key in arrays)
     assert visualizations == {}
 


### PR DESCRIPTION
We do not need to return every single % of variance explained from 0 to `n_components`.

Also, since we are now returning things that are not projections, renaming the variable seems prudent.