### PR TITLE
Extend `format_layer_spec` to handle all TransformerLens layer naming patterns

### DIFF
--- a/simplexity/analysis/metric_keys.py
+++ b/simplexity/analysis/metric_keys.py
@@ -23,9 +23,12 @@ def format_layer_spec(layer_name: str) -> str:
     """Format layer name into compact layer specification.
 
     Converts verbose layer names to compact specs:
-    - Block layers: "blocks.N.hook_X_Y" → "LN.X.Y"
-    - Special layers: "embed", "pos_embed", "ln_final" → unchanged
     - Concatenated: "concatenated" → "Lcat"
+    - Top-level hooks: "hook_embed" → "embed", "hook_pos_embed" → "pos_embed"
+    - Block direct hooks: "blocks.N.hook_X_Y" → "LN.X.Y"
+    - Block component hooks: "blocks.N.{comp}.hook_X" → "LN.{comp}.X"
+    - ln_final hooks: "ln_final.hook_X" → "ln_final.X"
+    - Other layers: unchanged
 
     Args:
         layer_name: Original layer name from activations dict
@@ -36,27 +39,42 @@ def format_layer_spec(layer_name: str) -> str:
     Examples:
         >>> format_layer_spec("blocks.2.hook_resid_post")
         "L2.resid.post"
-        >>> format_layer_spec("blocks.0.hook_resid_pre")
-        "L0.resid.pre"
-        >>> format_layer_spec("blocks.10.hook_mlp_out")
-        "L10.mlp.out"
-        >>> format_layer_spec("embed")
+        >>> format_layer_spec("blocks.0.attn.hook_q")
+        "L0.attn.q"
+        >>> format_layer_spec("hook_embed")
         "embed"
+        >>> format_layer_spec("ln_final.hook_scale")
+        "ln_final.scale"
         >>> format_layer_spec("concatenated")
         "Lcat"
     """
     if layer_name == "concatenated":
         return "Lcat"
 
+    if layer_name.startswith("hook_"):
+        return layer_name[5:]
+
+    ln_final_pattern = r"^ln_final\.hook_(?P<hook_name>.+)$"
+    match = re.match(ln_final_pattern, layer_name)
+    if match:
+        return f"ln_final.{match.group('hook_name')}"
+
     if not layer_name.startswith("blocks."):
         return layer_name
 
-    block_pattern = r"^blocks\.(?P<block_num>\d+)\.hook_(?P<hook_name>.+)$"
-    match = re.match(block_pattern, layer_name)
+    direct_hook_pattern = r"^blocks\.(?P<block_num>\d+)\.hook_(?P<hook_name>.+)$"
+    match = re.match(direct_hook_pattern, layer_name)
     if match:
         block_num = match.group("block_num")
-        hook_name = match.group("hook_name")
-        simplified_hook_name = hook_name.replace("_", ".")
-        return f"L{block_num}.{simplified_hook_name}"
+        hook_name = match.group("hook_name").replace("_", ".")
+        return f"L{block_num}.{hook_name}"
+
+    component_hook_pattern = r"^blocks\.(?P<block_num>\d+)\.(?P<component>\w+)\.hook_(?P<hook_name>.+)$"
+    match = re.match(component_hook_pattern, layer_name)
+    if match:
+        block_num = match.group("block_num")
+        component = match.group("component")
+        hook_name = match.group("hook_name").replace("_", ".")
+        return f"L{block_num}.{component}.{hook_name}"
 
     return layer_name

--- a/tests/analysis/test_metric_keys.py
+++ b/tests/analysis/test_metric_keys.py
@@ -59,3 +59,47 @@ def test_format_layer_spec_block_and_hook_layer_with_extra_structure() -> None:
     layer_name = "blocks.2.hook_resid_post.invalid"
     expected_key = "L2.resid.post.invalid"
     assert format_layer_spec(layer_name) == expected_key
+
+
+def test_format_layer_spec_hook_embed() -> None:
+    """Test that hook_embed is formatted to embed."""
+    assert format_layer_spec("hook_embed") == "embed"
+
+
+def test_format_layer_spec_hook_pos_embed() -> None:
+    """Test that hook_pos_embed is formatted to pos_embed."""
+    assert format_layer_spec("hook_pos_embed") == "pos_embed"
+
+
+def test_format_layer_spec_block_component_attn_hook() -> None:
+    """Test that block attention component hooks are formatted correctly."""
+    assert format_layer_spec("blocks.0.attn.hook_q") == "L0.attn.q"
+    assert format_layer_spec("blocks.1.attn.hook_k") == "L1.attn.k"
+    assert format_layer_spec("blocks.2.attn.hook_v") == "L2.attn.v"
+    assert format_layer_spec("blocks.0.attn.hook_attn_scores") == "L0.attn.attn.scores"
+    assert format_layer_spec("blocks.0.attn.hook_pattern") == "L0.attn.pattern"
+    assert format_layer_spec("blocks.0.attn.hook_z") == "L0.attn.z"
+
+
+def test_format_layer_spec_block_component_ln_hook() -> None:
+    """Test that block layer norm hooks are formatted correctly."""
+    assert format_layer_spec("blocks.0.ln1.hook_scale") == "L0.ln1.scale"
+    assert format_layer_spec("blocks.0.ln1.hook_normalized") == "L0.ln1.normalized"
+    assert format_layer_spec("blocks.1.ln2.hook_scale") == "L1.ln2.scale"
+
+
+def test_format_layer_spec_block_component_mlp_hook() -> None:
+    """Test that block MLP hooks are formatted correctly."""
+    assert format_layer_spec("blocks.0.mlp.hook_pre") == "L0.mlp.pre"
+    assert format_layer_spec("blocks.0.mlp.hook_post") == "L0.mlp.post"
+
+
+def test_format_layer_spec_ln_final_hook() -> None:
+    """Test that ln_final hooks are formatted correctly."""
+    assert format_layer_spec("ln_final.hook_scale") == "ln_final.scale"
+    assert format_layer_spec("ln_final.hook_normalized") == "ln_final.normalized"
+
+
+def test_format_layer_spec_ln_final_passthrough() -> None:
+    """Test that ln_final without hook prefix is passed through unchanged."""
+    assert format_layer_spec("ln_final") == "ln_final"


### PR DESCRIPTION
## Summary
  - Add support for top-level hooks (`hook_embed` → `embed`, `hook_pos_embed` → `pos_embed`)
  - Add support for block component hooks (`blocks.N.{comp}.hook_X` → `LN.{comp}.X`)
  - Add support for ln_final hooks (`ln_final.hook_X` → `ln_final.X`)

  ## Test plan
  - [x] Added 7 new test cases covering all new patterns
  - [x] All 15 tests pass
  - [x] Linting and type checking pass

  🤖 Generated with [Claude Code](https://claude.com/claude-code)