### PR TITLE
Add IndependentFactoredGenerativeProcess for frozen factor support

### DIFF
--- a/simplexity/generative_processes/independent_factored_generative_process.py
+++ b/simplexity/generative_processes/independent_factored_generative_process.py
@@ -98,9 +98,7 @@ class IndependentFactoredGenerativeProcess(FactoredGenerativeProcess):
         self.frozen_factor_indices = frozen_factor_indices
         self.frozen_key = frozen_key
 
-    def _emit_observation_per_factor(
-        self, state: FactoredState, key: jax.Array, frozen_key: jax.Array
-    ) -> jax.Array:
+    def _emit_observation_per_factor(self, state: FactoredState, key: jax.Array, frozen_key: jax.Array) -> jax.Array:
         """Sample each factor independently, choosing key based on frozen status.
 
         Args:
@@ -166,11 +164,7 @@ class IndependentFactoredGenerativeProcess(FactoredGenerativeProcess):
             Tuple of (final_states or all_states, observations)
         """
         keys = jax.random.split(key, sequence_len)
-        frozen_keys = (
-            jax.random.split(self.frozen_key, sequence_len)
-            if self.frozen_key is not None
-            else keys
-        )
+        frozen_keys = jax.random.split(self.frozen_key, sequence_len) if self.frozen_key is not None else keys
 
         def gen_obs(
             carry_state: FactoredState, inputs: tuple[jax.Array, jax.Array]

--- a/simplexity/generative_processes/independent_factored_generative_process.py
+++ b/simplexity/generative_processes/independent_factored_generative_process.py
@@ -38,7 +38,7 @@ class IndependentFactoredGenerativeProcess(FactoredGenerativeProcess):
     """
 
     frozen_factor_indices: frozenset[int]
-    frozen_key: jax.Array
+    frozen_key: jax.Array | None
 
     def __init__(
         self,
@@ -96,9 +96,9 @@ class IndependentFactoredGenerativeProcess(FactoredGenerativeProcess):
             )
 
         self.frozen_factor_indices = frozen_factor_indices
-        self.frozen_key = frozen_key if frozen_key is not None else jax.random.PRNGKey(0)
+        self.frozen_key = frozen_key
 
-    def _emit_observation_dual_key(
+    def _emit_observation_per_factor(
         self, state: FactoredState, key: jax.Array, frozen_key: jax.Array
     ) -> jax.Array:
         """Sample each factor independently, choosing key based on frozen status.
@@ -143,7 +143,8 @@ class IndependentFactoredGenerativeProcess(FactoredGenerativeProcess):
         Returns:
             Composite observation (scalar token)
         """
-        return self._emit_observation_dual_key(state, key, self.frozen_key)
+        frozen_key = self.frozen_key if self.frozen_key is not None else key
+        return self._emit_observation_per_factor(state, key, frozen_key)
 
     @eqx.filter_vmap(in_axes=(None, 0, 0, None, None))
     def generate(
@@ -165,13 +166,17 @@ class IndependentFactoredGenerativeProcess(FactoredGenerativeProcess):
             Tuple of (final_states or all_states, observations)
         """
         keys = jax.random.split(key, sequence_len)
-        frozen_keys = jax.random.split(self.frozen_key, sequence_len)
+        frozen_keys = (
+            jax.random.split(self.frozen_key, sequence_len)
+            if self.frozen_key is not None
+            else keys
+        )
 
         def gen_obs(
             carry_state: FactoredState, inputs: tuple[jax.Array, jax.Array]
         ) -> tuple[FactoredState, chex.Array]:
             key_t, frozen_key_t = inputs
-            obs = self._emit_observation_dual_key(carry_state, key_t, frozen_key_t)
+            obs = self._emit_observation_per_factor(carry_state, key_t, frozen_key_t)
             new_state = self.transition_states(carry_state, obs)
             return new_state, obs
 
@@ -179,7 +184,7 @@ class IndependentFactoredGenerativeProcess(FactoredGenerativeProcess):
             carry_state: FactoredState, inputs: tuple[jax.Array, jax.Array]
         ) -> tuple[FactoredState, tuple[FactoredState, chex.Array]]:
             key_t, frozen_key_t = inputs
-            obs = self._emit_observation_dual_key(carry_state, key_t, frozen_key_t)
+            obs = self._emit_observation_per_factor(carry_state, key_t, frozen_key_t)
             new_state = self.transition_states(carry_state, obs)
             return new_state, (carry_state, obs)
 

--- a/simplexity/generative_processes/independent_factored_generative_process.py
+++ b/simplexity/generative_processes/independent_factored_generative_process.py
@@ -1,0 +1,190 @@
+"""Independent factored generative process with per-factor sampling and frozen factors."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import chex
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+
+from simplexity.generative_processes.factored_generative_process import (
+    ComponentType,
+    FactoredGenerativeProcess,
+    FactoredState,
+)
+from simplexity.generative_processes.structures import ConditionalStructure
+from simplexity.generative_processes.structures.independent import IndependentStructure
+from simplexity.logger import SIMPLEXITY_LOGGER
+from simplexity.utils.factoring_utils import compute_obs_dist_for_variant
+
+
+class IndependentFactoredGenerativeProcess(FactoredGenerativeProcess):
+    """Factored generative process with independent per-factor sampling and frozen factors.
+
+    This variant samples emissions from each factor independently (not from the joint
+    distribution), then combines them using TokenEncoder.tuple_to_token. It also supports
+    "frozen" factors whose entire emission sequences are identical across batch samples.
+
+    Frozen factors use keys derived from a stored `frozen_key`, while unfrozen factors
+    use keys derived from the per-sample key. Since the same `frozen_key` produces the
+    same derived keys across all batch samples, frozen factors naturally produce
+    identical sequences.
+
+    Attributes:
+        frozen_factor_indices: frozenset of factor indices that are frozen
+        frozen_key: JAX random key used for generating frozen sequences
+    """
+
+    frozen_factor_indices: frozenset[int]
+    frozen_key: jax.Array
+
+    def __init__(
+        self,
+        *,
+        component_types: Sequence[ComponentType],
+        transition_matrices: Sequence[jax.Array],
+        normalizing_eigenvectors: Sequence[jax.Array],
+        initial_states: Sequence[jax.Array],
+        structure: ConditionalStructure,
+        device: str | None = None,
+        frozen_factor_indices: frozenset[int] = frozenset(),
+        frozen_key: jax.Array | None = None,
+    ) -> None:
+        """Initialize independent factored generative process.
+
+        Args:
+            component_types: Type of each factor ("hmm" or "ghmm")
+            transition_matrices: Per-factor transition tensors.
+                transition_matrices[i] has shape [K_i, V_i, S_i, S_i]
+            normalizing_eigenvectors: Per-factor eigenvectors for GHMM.
+                normalizing_eigenvectors[i] has shape [K_i, S_i]
+            initial_states: Initial state per factor (shape [S_i])
+            structure: Conditional structure defining factor interactions
+            device: Device to place arrays on (e.g., "cpu", "gpu")
+            frozen_factor_indices: Indices of factors whose sequences are frozen across batch
+            frozen_key: JAX random key for frozen sequence generation. Required if
+                frozen_factor_indices is non-empty.
+
+        Raises:
+            ValueError: If frozen_factor_indices is non-empty but frozen_key is None
+            ValueError: If frozen_factor_indices contains invalid indices
+        """
+        super().__init__(
+            component_types=component_types,
+            transition_matrices=transition_matrices,
+            normalizing_eigenvectors=normalizing_eigenvectors,
+            initial_states=initial_states,
+            structure=structure,
+            device=device,
+        )
+
+        num_factors = len(component_types)
+        for idx in frozen_factor_indices:
+            if idx < 0 or idx >= num_factors:
+                raise ValueError(f"Invalid frozen factor index {idx}. Must be in [0, {num_factors})")
+
+        if frozen_factor_indices and frozen_key is None:
+            raise ValueError("frozen_key is required when frozen_factor_indices is non-empty")
+
+        if not isinstance(structure, IndependentStructure):
+            SIMPLEXITY_LOGGER.warning(
+                "IndependentFactoredGenerativeProcess is designed for IndependentStructure. "
+                "Using %s may produce unexpected results.",
+                type(structure).__name__,
+            )
+
+        self.frozen_factor_indices = frozen_factor_indices
+        self.frozen_key = frozen_key if frozen_key is not None else jax.random.PRNGKey(0)
+
+    def _emit_observation_dual_key(
+        self, state: FactoredState, key: jax.Array, frozen_key: jax.Array
+    ) -> jax.Array:
+        """Sample each factor independently, choosing key based on frozen status.
+
+        Args:
+            state: Tuple of state vectors (one per factor)
+            key: JAX random key for unfrozen factors
+            frozen_key: JAX random key for frozen factors
+
+        Returns:
+            Composite observation (scalar token)
+        """
+        num_factors = len(self.component_types)
+
+        factor_keys = jax.random.split(key, num_factors)
+        frozen_factor_keys = jax.random.split(frozen_key, num_factors)
+
+        per_factor_tokens = []
+        for i in range(num_factors):
+            if i in self.frozen_factor_indices:
+                factor_key = frozen_factor_keys[i]
+            else:
+                factor_key = factor_keys[i]
+
+            T_i = self.transition_matrices[i][0]
+            norm_i = self.normalizing_eigenvectors[i][0] if self.component_types[i] == "ghmm" else None
+            p_i = compute_obs_dist_for_variant(self.component_types[i], state[i], T_i, norm_i)
+
+            token_i = jax.random.categorical(factor_key, jnp.log(p_i))
+            per_factor_tokens.append(token_i)
+
+        return self.encoder.tuple_to_token(tuple(per_factor_tokens))
+
+    @eqx.filter_jit
+    def emit_observation(self, state: FactoredState, key: jax.Array) -> jax.Array:
+        """Sample composite observation by independently sampling each factor.
+
+        Args:
+            state: Tuple of state vectors (one per factor)
+            key: JAX random key
+
+        Returns:
+            Composite observation (scalar token)
+        """
+        return self._emit_observation_dual_key(state, key, self.frozen_key)
+
+    @eqx.filter_vmap(in_axes=(None, 0, 0, None, None))
+    def generate(
+        self, state: FactoredState, key: chex.PRNGKey, sequence_len: int, return_all_states: bool
+    ) -> tuple[FactoredState, chex.Array]:
+        """Generate sequences with frozen factor support.
+
+        For frozen factors, the same key stream is used across all batch samples,
+        producing identical emission sequences. For unfrozen factors, each batch
+        sample uses its own key stream, producing varying sequences.
+
+        Args:
+            state: Initial states, one per factor
+            key: Random key for this batch sample
+            sequence_len: Number of timesteps to generate
+            return_all_states: Whether to return all intermediate states
+
+        Returns:
+            Tuple of (final_states or all_states, observations)
+        """
+        keys = jax.random.split(key, sequence_len)
+        frozen_keys = jax.random.split(self.frozen_key, sequence_len)
+
+        def gen_obs(
+            carry_state: FactoredState, inputs: tuple[jax.Array, jax.Array]
+        ) -> tuple[FactoredState, chex.Array]:
+            key_t, frozen_key_t = inputs
+            obs = self._emit_observation_dual_key(carry_state, key_t, frozen_key_t)
+            new_state = self.transition_states(carry_state, obs)
+            return new_state, obs
+
+        def gen_states_and_obs(
+            carry_state: FactoredState, inputs: tuple[jax.Array, jax.Array]
+        ) -> tuple[FactoredState, tuple[FactoredState, chex.Array]]:
+            key_t, frozen_key_t = inputs
+            obs = self._emit_observation_dual_key(carry_state, key_t, frozen_key_t)
+            new_state = self.transition_states(carry_state, obs)
+            return new_state, (carry_state, obs)
+
+        if return_all_states:
+            _, (states, obs) = jax.lax.scan(gen_states_and_obs, state, (keys, frozen_keys))
+            return states, obs
+
+        return jax.lax.scan(gen_obs, state, (keys, frozen_keys))

--- a/tests/generative_processes/test_independent_factored_generative_process.py
+++ b/tests/generative_processes/test_independent_factored_generative_process.py
@@ -147,7 +147,7 @@ class TestFrozenFactors:
         keys = jax.random.split(jax.random.PRNGKey(123), batch_size)
 
         _, observations = process.generate(batch_states, keys, seq_len, False)
-        factor_tokens = jax.vmap(lambda obs: process.encoder.extract_factors_vectorized(obs))(observations)
+        factor_tokens = jax.vmap(process.encoder.extract_factors_vectorized)(observations)
 
         # Factor 1 (index 1) is frozen - should be identical across batch
         frozen_factor_sequences = factor_tokens[:, :, 1]
@@ -164,7 +164,7 @@ class TestFrozenFactors:
         keys = jax.random.split(jax.random.PRNGKey(456), batch_size)
 
         _, observations = process.generate(batch_states, keys, seq_len, False)
-        factor_tokens = jax.vmap(lambda obs: process.encoder.extract_factors_vectorized(obs))(observations)
+        factor_tokens = jax.vmap(process.encoder.extract_factors_vectorized)(observations)
 
         # Factors 0 and 2 are unfrozen - should differ across batch
         unfrozen_0_sequences = factor_tokens[:, :, 0]
@@ -185,12 +185,12 @@ class TestFrozenFactors:
         # First generation
         keys1 = jax.random.split(jax.random.PRNGKey(100), batch_size)
         _, obs1 = process.generate(batch_states, keys1, seq_len, False)
-        factor_tokens1 = jax.vmap(lambda obs: process.encoder.extract_factors_vectorized(obs))(obs1)
+        factor_tokens1 = jax.vmap(process.encoder.extract_factors_vectorized)(obs1)
 
         # Second generation with different sample keys
         keys2 = jax.random.split(jax.random.PRNGKey(200), batch_size)
         _, obs2 = process.generate(batch_states, keys2, seq_len, False)
-        factor_tokens2 = jax.vmap(lambda obs: process.encoder.extract_factors_vectorized(obs))(obs2)
+        factor_tokens2 = jax.vmap(process.encoder.extract_factors_vectorized)(obs2)
 
         # Frozen factor should be the same in both calls
         chex.assert_trees_all_equal(factor_tokens1[:, :, 1], factor_tokens2[:, :, 1])
@@ -332,7 +332,7 @@ class TestValidation:
         assert "IndependentFactoredGenerativeProcess is designed for IndependentStructure" in caplog.text
 
 
-class TestStateTransitions:
+class TestStateTransitions:  # pylint: disable=too-few-public-methods
     """Tests for state transitions with frozen factors."""
 
     def test_frozen_factor_states_match_across_batch(self, three_factor_process_with_frozen):

--- a/tests/generative_processes/test_independent_factored_generative_process.py
+++ b/tests/generative_processes/test_independent_factored_generative_process.py
@@ -109,9 +109,7 @@ class TestGenerate:
         batch_size = 4
         seq_len = 10
 
-        batch_states = tuple(
-            jnp.tile(s[None, :], (batch_size, 1)) for s in process.initial_state
-        )
+        batch_states = tuple(jnp.tile(s[None, :], (batch_size, 1)) for s in process.initial_state)
         keys = jax.random.split(jax.random.PRNGKey(0), batch_size)
 
         final_states, observations = process.generate(batch_states, keys, seq_len, False)
@@ -126,9 +124,7 @@ class TestGenerate:
         batch_size = 4
         seq_len = 10
 
-        batch_states = tuple(
-            jnp.tile(s[None, :], (batch_size, 1)) for s in process.initial_state
-        )
+        batch_states = tuple(jnp.tile(s[None, :], (batch_size, 1)) for s in process.initial_state)
         keys = jax.random.split(jax.random.PRNGKey(0), batch_size)
 
         all_states, observations = process.generate(batch_states, keys, seq_len, True)
@@ -147,15 +143,11 @@ class TestFrozenFactors:
         batch_size = 8
         seq_len = 20
 
-        batch_states = tuple(
-            jnp.tile(s[None, :], (batch_size, 1)) for s in process.initial_state
-        )
+        batch_states = tuple(jnp.tile(s[None, :], (batch_size, 1)) for s in process.initial_state)
         keys = jax.random.split(jax.random.PRNGKey(123), batch_size)
 
         _, observations = process.generate(batch_states, keys, seq_len, False)
-        factor_tokens = jax.vmap(
-            lambda obs: process.encoder.extract_factors_vectorized(obs)
-        )(observations)
+        factor_tokens = jax.vmap(lambda obs: process.encoder.extract_factors_vectorized(obs))(observations)
 
         # Factor 1 (index 1) is frozen - should be identical across batch
         frozen_factor_sequences = factor_tokens[:, :, 1]
@@ -168,15 +160,11 @@ class TestFrozenFactors:
         batch_size = 8
         seq_len = 20
 
-        batch_states = tuple(
-            jnp.tile(s[None, :], (batch_size, 1)) for s in process.initial_state
-        )
+        batch_states = tuple(jnp.tile(s[None, :], (batch_size, 1)) for s in process.initial_state)
         keys = jax.random.split(jax.random.PRNGKey(456), batch_size)
 
         _, observations = process.generate(batch_states, keys, seq_len, False)
-        factor_tokens = jax.vmap(
-            lambda obs: process.encoder.extract_factors_vectorized(obs)
-        )(observations)
+        factor_tokens = jax.vmap(lambda obs: process.encoder.extract_factors_vectorized(obs))(observations)
 
         # Factors 0 and 2 are unfrozen - should differ across batch
         unfrozen_0_sequences = factor_tokens[:, :, 0]
@@ -192,23 +180,17 @@ class TestFrozenFactors:
         batch_size = 4
         seq_len = 15
 
-        batch_states = tuple(
-            jnp.tile(s[None, :], (batch_size, 1)) for s in process.initial_state
-        )
+        batch_states = tuple(jnp.tile(s[None, :], (batch_size, 1)) for s in process.initial_state)
 
         # First generation
         keys1 = jax.random.split(jax.random.PRNGKey(100), batch_size)
         _, obs1 = process.generate(batch_states, keys1, seq_len, False)
-        factor_tokens1 = jax.vmap(
-            lambda obs: process.encoder.extract_factors_vectorized(obs)
-        )(obs1)
+        factor_tokens1 = jax.vmap(lambda obs: process.encoder.extract_factors_vectorized(obs))(obs1)
 
         # Second generation with different sample keys
         keys2 = jax.random.split(jax.random.PRNGKey(200), batch_size)
         _, obs2 = process.generate(batch_states, keys2, seq_len, False)
-        factor_tokens2 = jax.vmap(
-            lambda obs: process.encoder.extract_factors_vectorized(obs)
-        )(obs2)
+        factor_tokens2 = jax.vmap(lambda obs: process.encoder.extract_factors_vectorized(obs))(obs2)
 
         # Frozen factor should be the same in both calls
         chex.assert_trees_all_equal(factor_tokens1[:, :, 1], factor_tokens2[:, :, 1])
@@ -241,9 +223,7 @@ class TestFrozenFactors:
 
         batch_size = 4
         seq_len = 10
-        batch_states = tuple(
-            jnp.tile(s[None, :], (batch_size, 1)) for s in process.initial_state
-        )
+        batch_states = tuple(jnp.tile(s[None, :], (batch_size, 1)) for s in process.initial_state)
         keys = jax.random.split(jax.random.PRNGKey(0), batch_size)
 
         _, observations = process.generate(batch_states, keys, seq_len, False)
@@ -258,9 +238,7 @@ class TestFrozenFactors:
         batch_size = 4
         seq_len = 10
 
-        batch_states = tuple(
-            jnp.tile(s[None, :], (batch_size, 1)) for s in process.initial_state
-        )
+        batch_states = tuple(jnp.tile(s[None, :], (batch_size, 1)) for s in process.initial_state)
         keys = jax.random.split(jax.random.PRNGKey(0), batch_size)
 
         _, observations = process.generate(batch_states, keys, seq_len, False)
@@ -363,9 +341,7 @@ class TestStateTransitions:
         batch_size = 4
         seq_len = 10
 
-        batch_states = tuple(
-            jnp.tile(s[None, :], (batch_size, 1)) for s in process.initial_state
-        )
+        batch_states = tuple(jnp.tile(s[None, :], (batch_size, 1)) for s in process.initial_state)
         keys = jax.random.split(jax.random.PRNGKey(789), batch_size)
 
         all_states, _ = process.generate(batch_states, keys, seq_len, True)

--- a/tests/generative_processes/test_independent_factored_generative_process.py
+++ b/tests/generative_processes/test_independent_factored_generative_process.py
@@ -1,0 +1,376 @@
+"""Tests for IndependentFactoredGenerativeProcess."""
+
+import chex
+import jax
+import jax.numpy as jnp
+import pytest
+
+from simplexity.generative_processes.independent_factored_generative_process import (
+    IndependentFactoredGenerativeProcess,
+)
+from simplexity.generative_processes.structures import IndependentStructure, SequentialConditional
+
+
+def _tensor_from_probs(variant_probs):
+    arr = jnp.asarray(variant_probs, dtype=jnp.float32)
+    return arr[..., None, None]
+
+
+@pytest.fixture
+def two_factor_independent_process():
+    """Simple two-factor process with IndependentStructure."""
+    component_types = ("hmm", "hmm")
+    transition_matrices = (
+        _tensor_from_probs([[0.6, 0.4]]),
+        _tensor_from_probs([[0.7, 0.3]]),
+    )
+    normalizing_eigenvectors = (
+        jnp.ones((1, 1), dtype=jnp.float32),
+        jnp.ones((1, 1), dtype=jnp.float32),
+    )
+    initial_states = (
+        jnp.array([1.0], dtype=jnp.float32),
+        jnp.array([1.0], dtype=jnp.float32),
+    )
+    structure = IndependentStructure()
+    return IndependentFactoredGenerativeProcess(
+        component_types=component_types,
+        transition_matrices=transition_matrices,
+        normalizing_eigenvectors=normalizing_eigenvectors,
+        initial_states=initial_states,
+        structure=structure,
+    )
+
+
+@pytest.fixture
+def three_factor_process_with_frozen():
+    """Three-factor process with factor 1 frozen."""
+    component_types = ("hmm", "hmm", "hmm")
+    transition_matrices = (
+        _tensor_from_probs([[0.6, 0.4]]),
+        _tensor_from_probs([[0.7, 0.3]]),
+        _tensor_from_probs([[0.8, 0.2]]),
+    )
+    normalizing_eigenvectors = (
+        jnp.ones((1, 1), dtype=jnp.float32),
+        jnp.ones((1, 1), dtype=jnp.float32),
+        jnp.ones((1, 1), dtype=jnp.float32),
+    )
+    initial_states = (
+        jnp.array([1.0], dtype=jnp.float32),
+        jnp.array([1.0], dtype=jnp.float32),
+        jnp.array([1.0], dtype=jnp.float32),
+    )
+    structure = IndependentStructure()
+    return IndependentFactoredGenerativeProcess(
+        component_types=component_types,
+        transition_matrices=transition_matrices,
+        normalizing_eigenvectors=normalizing_eigenvectors,
+        initial_states=initial_states,
+        structure=structure,
+        frozen_factor_indices=frozenset({1}),
+        frozen_key=jax.random.PRNGKey(42),
+    )
+
+
+class TestEmitObservation:
+    """Tests for emit_observation method."""
+
+    def test_emit_observation_returns_valid_token(self, two_factor_independent_process):
+        """emit_observation should return a valid composite token."""
+        process = two_factor_independent_process
+        token = process.emit_observation(process.initial_state, jax.random.PRNGKey(0))
+        assert token.shape == ()
+        assert 0 <= int(token) < process.vocab_size
+
+    def test_emit_observation_samples_independently(self, two_factor_independent_process):
+        """Samples should match product of marginal distributions."""
+        process = two_factor_independent_process
+        n_samples = 10000
+        keys = jax.random.split(jax.random.PRNGKey(0), n_samples)
+
+        tokens = jax.vmap(lambda k: process.emit_observation(process.initial_state, k))(keys)
+        factor_tokens = process.encoder.extract_factors_vectorized(tokens)
+
+        # Expected marginals: factor 0 is [0.6, 0.4], factor 1 is [0.7, 0.3]
+        empirical_0 = jnp.bincount(factor_tokens[:, 0], length=2) / n_samples
+        empirical_1 = jnp.bincount(factor_tokens[:, 1], length=2) / n_samples
+
+        chex.assert_trees_all_close(empirical_0, jnp.array([0.6, 0.4]), atol=0.05)
+        chex.assert_trees_all_close(empirical_1, jnp.array([0.7, 0.3]), atol=0.05)
+
+
+class TestGenerate:
+    """Tests for generate method."""
+
+    def test_generate_produces_correct_shapes(self, two_factor_independent_process):
+        """generate should produce correctly shaped outputs."""
+        process = two_factor_independent_process
+        batch_size = 4
+        seq_len = 10
+
+        batch_states = tuple(
+            jnp.tile(s[None, :], (batch_size, 1)) for s in process.initial_state
+        )
+        keys = jax.random.split(jax.random.PRNGKey(0), batch_size)
+
+        final_states, observations = process.generate(batch_states, keys, seq_len, False)
+
+        assert observations.shape == (batch_size, seq_len)
+        assert final_states[0].shape == (batch_size, 1)
+        assert final_states[1].shape == (batch_size, 1)
+
+    def test_generate_returns_all_states_when_requested(self, two_factor_independent_process):
+        """generate with return_all_states=True should return state sequences."""
+        process = two_factor_independent_process
+        batch_size = 4
+        seq_len = 10
+
+        batch_states = tuple(
+            jnp.tile(s[None, :], (batch_size, 1)) for s in process.initial_state
+        )
+        keys = jax.random.split(jax.random.PRNGKey(0), batch_size)
+
+        all_states, observations = process.generate(batch_states, keys, seq_len, True)
+
+        assert observations.shape == (batch_size, seq_len)
+        assert all_states[0].shape == (batch_size, seq_len, 1)
+        assert all_states[1].shape == (batch_size, seq_len, 1)
+
+
+class TestFrozenFactors:
+    """Tests for frozen factor behavior."""
+
+    def test_frozen_factor_same_across_batch(self, three_factor_process_with_frozen):
+        """Frozen factor should produce identical sequences across batch samples."""
+        process = three_factor_process_with_frozen
+        batch_size = 8
+        seq_len = 20
+
+        batch_states = tuple(
+            jnp.tile(s[None, :], (batch_size, 1)) for s in process.initial_state
+        )
+        keys = jax.random.split(jax.random.PRNGKey(123), batch_size)
+
+        _, observations = process.generate(batch_states, keys, seq_len, False)
+        factor_tokens = jax.vmap(
+            lambda obs: process.encoder.extract_factors_vectorized(obs)
+        )(observations)
+
+        # Factor 1 (index 1) is frozen - should be identical across batch
+        frozen_factor_sequences = factor_tokens[:, :, 1]
+        for i in range(1, batch_size):
+            chex.assert_trees_all_equal(frozen_factor_sequences[0], frozen_factor_sequences[i])
+
+    def test_unfrozen_factors_vary_across_batch(self, three_factor_process_with_frozen):
+        """Unfrozen factors should vary across batch samples."""
+        process = three_factor_process_with_frozen
+        batch_size = 8
+        seq_len = 20
+
+        batch_states = tuple(
+            jnp.tile(s[None, :], (batch_size, 1)) for s in process.initial_state
+        )
+        keys = jax.random.split(jax.random.PRNGKey(456), batch_size)
+
+        _, observations = process.generate(batch_states, keys, seq_len, False)
+        factor_tokens = jax.vmap(
+            lambda obs: process.encoder.extract_factors_vectorized(obs)
+        )(observations)
+
+        # Factors 0 and 2 are unfrozen - should differ across batch
+        unfrozen_0_sequences = factor_tokens[:, :, 0]
+        unfrozen_2_sequences = factor_tokens[:, :, 2]
+
+        # Check that not all samples are identical
+        assert not jnp.all(unfrozen_0_sequences[0] == unfrozen_0_sequences[1])
+        assert not jnp.all(unfrozen_2_sequences[0] == unfrozen_2_sequences[1])
+
+    def test_frozen_sequences_reproducible(self, three_factor_process_with_frozen):
+        """Frozen factor sequences should be reproducible across generate() calls."""
+        process = three_factor_process_with_frozen
+        batch_size = 4
+        seq_len = 15
+
+        batch_states = tuple(
+            jnp.tile(s[None, :], (batch_size, 1)) for s in process.initial_state
+        )
+
+        # First generation
+        keys1 = jax.random.split(jax.random.PRNGKey(100), batch_size)
+        _, obs1 = process.generate(batch_states, keys1, seq_len, False)
+        factor_tokens1 = jax.vmap(
+            lambda obs: process.encoder.extract_factors_vectorized(obs)
+        )(obs1)
+
+        # Second generation with different sample keys
+        keys2 = jax.random.split(jax.random.PRNGKey(200), batch_size)
+        _, obs2 = process.generate(batch_states, keys2, seq_len, False)
+        factor_tokens2 = jax.vmap(
+            lambda obs: process.encoder.extract_factors_vectorized(obs)
+        )(obs2)
+
+        # Frozen factor should be the same in both calls
+        chex.assert_trees_all_equal(factor_tokens1[:, :, 1], factor_tokens2[:, :, 1])
+
+    def test_all_factors_frozen(self):
+        """With all factors frozen, all batch samples should be identical."""
+        component_types = ("hmm", "hmm")
+        transition_matrices = (
+            _tensor_from_probs([[0.6, 0.4]]),
+            _tensor_from_probs([[0.7, 0.3]]),
+        )
+        normalizing_eigenvectors = (
+            jnp.ones((1, 1), dtype=jnp.float32),
+            jnp.ones((1, 1), dtype=jnp.float32),
+        )
+        initial_states = (
+            jnp.array([1.0], dtype=jnp.float32),
+            jnp.array([1.0], dtype=jnp.float32),
+        )
+        structure = IndependentStructure()
+        process = IndependentFactoredGenerativeProcess(
+            component_types=component_types,
+            transition_matrices=transition_matrices,
+            normalizing_eigenvectors=normalizing_eigenvectors,
+            initial_states=initial_states,
+            structure=structure,
+            frozen_factor_indices=frozenset({0, 1}),
+            frozen_key=jax.random.PRNGKey(999),
+        )
+
+        batch_size = 4
+        seq_len = 10
+        batch_states = tuple(
+            jnp.tile(s[None, :], (batch_size, 1)) for s in process.initial_state
+        )
+        keys = jax.random.split(jax.random.PRNGKey(0), batch_size)
+
+        _, observations = process.generate(batch_states, keys, seq_len, False)
+
+        # All batch samples should be identical
+        for i in range(1, batch_size):
+            chex.assert_trees_all_equal(observations[0], observations[i])
+
+    def test_no_frozen_factors_matches_normal_behavior(self, two_factor_independent_process):
+        """With no frozen factors, behavior should match normal generation."""
+        process = two_factor_independent_process
+        batch_size = 4
+        seq_len = 10
+
+        batch_states = tuple(
+            jnp.tile(s[None, :], (batch_size, 1)) for s in process.initial_state
+        )
+        keys = jax.random.split(jax.random.PRNGKey(0), batch_size)
+
+        _, observations = process.generate(batch_states, keys, seq_len, False)
+
+        # All tokens should be valid
+        assert jnp.all(observations >= 0)
+        assert jnp.all(observations < process.vocab_size)
+
+        # Batch samples should differ (with high probability)
+        assert not jnp.all(observations[0] == observations[1])
+
+
+class TestValidation:
+    """Tests for constructor validation."""
+
+    def test_requires_frozen_key_when_frozen_indices_nonempty(self):
+        """Should raise ValueError if frozen_factor_indices is non-empty but frozen_key is None."""
+        component_types = ("hmm",)
+        transition_matrices = (_tensor_from_probs([[0.6, 0.4]]),)
+        normalizing_eigenvectors = (jnp.ones((1, 1), dtype=jnp.float32),)
+        initial_states = (jnp.array([1.0], dtype=jnp.float32),)
+        structure = IndependentStructure()
+
+        with pytest.raises(ValueError, match="frozen_key is required"):
+            IndependentFactoredGenerativeProcess(
+                component_types=component_types,
+                transition_matrices=transition_matrices,
+                normalizing_eigenvectors=normalizing_eigenvectors,
+                initial_states=initial_states,
+                structure=structure,
+                frozen_factor_indices=frozenset({0}),
+                frozen_key=None,
+            )
+
+    def test_rejects_invalid_frozen_factor_index(self):
+        """Should raise ValueError for out-of-range frozen factor indices."""
+        component_types = ("hmm", "hmm")
+        transition_matrices = (
+            _tensor_from_probs([[0.6, 0.4]]),
+            _tensor_from_probs([[0.7, 0.3]]),
+        )
+        normalizing_eigenvectors = (
+            jnp.ones((1, 1), dtype=jnp.float32),
+            jnp.ones((1, 1), dtype=jnp.float32),
+        )
+        initial_states = (
+            jnp.array([1.0], dtype=jnp.float32),
+            jnp.array([1.0], dtype=jnp.float32),
+        )
+        structure = IndependentStructure()
+
+        with pytest.raises(ValueError, match="Invalid frozen factor index 5"):
+            IndependentFactoredGenerativeProcess(
+                component_types=component_types,
+                transition_matrices=transition_matrices,
+                normalizing_eigenvectors=normalizing_eigenvectors,
+                initial_states=initial_states,
+                structure=structure,
+                frozen_factor_indices=frozenset({0, 5}),
+                frozen_key=jax.random.PRNGKey(0),
+            )
+
+    def test_warns_for_non_independent_structure(self, caplog):
+        """Should log warning when structure is not IndependentStructure."""
+        component_types = ("hmm", "hmm")
+        transition_matrices = (
+            _tensor_from_probs([[0.6, 0.4]]),
+            _tensor_from_probs([[0.7, 0.3], [0.2, 0.8]]),
+        )
+        normalizing_eigenvectors = (
+            jnp.ones((1, 1), dtype=jnp.float32),
+            jnp.ones((2, 1), dtype=jnp.float32),
+        )
+        initial_states = (
+            jnp.array([1.0], dtype=jnp.float32),
+            jnp.array([1.0], dtype=jnp.float32),
+        )
+        structure = SequentialConditional(
+            control_maps=(None, jnp.array([0, 1], dtype=jnp.int32)),
+            vocab_sizes=jnp.array([2, 2], dtype=jnp.int32),
+        )
+
+        IndependentFactoredGenerativeProcess(
+            component_types=component_types,
+            transition_matrices=transition_matrices,
+            normalizing_eigenvectors=normalizing_eigenvectors,
+            initial_states=initial_states,
+            structure=structure,
+        )
+
+        assert "IndependentFactoredGenerativeProcess is designed for IndependentStructure" in caplog.text
+
+
+class TestStateTransitions:
+    """Tests for state transitions with frozen factors."""
+
+    def test_frozen_factor_states_match_across_batch(self, three_factor_process_with_frozen):
+        """Frozen factor states should be identical across batch samples."""
+        process = three_factor_process_with_frozen
+        batch_size = 4
+        seq_len = 10
+
+        batch_states = tuple(
+            jnp.tile(s[None, :], (batch_size, 1)) for s in process.initial_state
+        )
+        keys = jax.random.split(jax.random.PRNGKey(789), batch_size)
+
+        all_states, _ = process.generate(batch_states, keys, seq_len, True)
+
+        # Factor 1 states should be identical across batch
+        frozen_factor_states = all_states[1]
+        for i in range(1, batch_size):
+            chex.assert_trees_all_close(frozen_factor_states[0], frozen_factor_states[i])


### PR DESCRIPTION
### Summary

Introduces `IndependentFactoredGenerativeProcess`, a subclass of `FactoredGenerativeProcess` that:
- Samples emissions from each factor **independently** (rather than from the joint distribution)
- Supports **frozen factors** whose emission sequences are identical across all batch samples

This enables generating datasets where k of n factors share the same realizations across samples while the remaining (n-k) factors vary independently.

### Motivation

When working with factored generative processes, it's useful to control which factors are held constant vs. which vary across a batch of generated sequences. This is particularly valuable for:
- Ablation studies isolating the effect of specific factors
- Generating controlled datasets with shared structure across samples
- Investigating factor-specific properties of sequence prediction models

### Implementation

The key mechanism is a **dual key stream** approach in `generate()`:
- **Frozen factors**: Use keys derived from a stored `frozen_key` (same across all batch samples → identical sequences)
- **Unfrozen factors**: Use keys derived from the per-sample key (different per sample → varying sequences)

```python
process = IndependentFactoredGenerativeProcess(
    component_types=("hmm", "hmm", "hmm"),
    transition_matrices=...,
    normalizing_eigenvectors=...,
    initial_states=...,
    structure=IndependentStructure(),
    frozen_factor_indices=frozenset({0, 2}),  # Factors 0 and 2 are frozen
    frozen_key=jax.random.PRNGKey(42),
)

# Factors 0 and 2 will be identical across all batch samples
states, observations = process.generate(batch_states, keys, seq_len, False)
```

### Changes

- New file: simplexity/generative_processes/independent_factored_generative_process.py
- New tests: tests/generative_processes/test_independent_factored_generative_process.py (13 tests, 100% coverage)

### Test plan

- All existing FactoredGenerativeProcess tests pass (no regressions)
- New tests verify frozen factor consistency across batch
- New tests verify unfrozen factor variation across batch
- New tests verify reproducibility of frozen sequences across generate() calls
- Edge cases covered: all frozen, none frozen, invalid indices
- Type checking passes (pyright)
- Linting passes (ruff)