### PR TITLE
Fix a clause doubled in the deprecation docstring

### DIFF
--- a/simplexity/generative_processes/__init__.py
+++ b/simplexity/generative_processes/__init__.py
@@ -4,7 +4,7 @@ Generative processes are moving out of simplexity and into consumers' own projec
 [generators](https://github.com/ealt/generators), which distributes process modules by
 copying rather than by import. Run management instantiates a vendored process on equal terms with
 one implemented here: see `simplexity.run_management.protocols.GenerativeProcessProtocol` for the
-and contract and `docs/generators_migration.md` for the migration.
+contract, and `docs/generators_migration.md` for the migration.
 
 Nothing here is removed or altered yet. Full deprecation waits until generators reaches feature
 parity with this package; `docs/design/generators_instantiation.md` tracks the outstanding gaps.


### PR DESCRIPTION
One-line docs fix. Follow-up to #198.

The module docstring of `simplexity/generative_processes` currently reads:

> see `simplexity.run_management.protocols.GenerativeProcessProtocol` for the
> **and contract and** `docs/generators_migration.md` for the migration.

Two scripted edits landed on the same sentence during the protocol rename in #198, and #198 merged
before I noticed. Cosmetic, but it is the docstring of the package the deprecation is about — the
first thing anyone following the `PendingDeprecationWarning` reads.

I swept the 1,927 lines #198 added for the same class of damage; this was the only instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XrVfBeUFhMToafrbgdDGUo